### PR TITLE
Create TextField, Checkbox, Spinner and simplify Button and ButtonIcon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
     'no-underscore-dangle': 0,
     'arrow-body-style': [1, 'as-needed'],
     'no-use-before-define': 'off',
+    'no-nested-ternary': 'off',
     '@typescript-eslint/no-use-before-define': ['error'],
     'import/extensions': [
       'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,10 @@ module.exports = {
     'arrow-body-style': [1, 'as-needed'],
     'no-use-before-define': 'off',
     'no-nested-ternary': 'off',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
     '@typescript-eslint/no-use-before-define': ['error'],
     'import/extensions': [
       'error',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,5 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/preset-create-react-app',
-    'storybook-formik/register',
   ],
 };

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,5 +4,6 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/preset-create-react-app',
+    'storybook-formik/register',
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
         "eslint-plugin-prettier": "^3.3.1",
         "eslint-plugin-react": "^7.23.1",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "prettier": "^2.2.1"
+        "prettier": "^2.2.1",
+        "storybook-formik": "^2.1.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7227,6 +7228,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/base16": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
+      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA=",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -16289,10 +16296,22 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "node_modules/lodash.curry": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
+      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA=",
+      "dev": true
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "node_modules/lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -19610,6 +19629,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-color": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
+      "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=",
+      "dev": true
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -19779,6 +19804,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-base16-styling": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.5.3.tgz",
+      "integrity": "sha1-OFjyTpxN2MvT9wLz901YHKKRcmk=",
+      "dev": true,
+      "dependencies": {
+        "base16": "^1.0.0",
+        "lodash.curry": "^4.0.1",
+        "lodash.flow": "^3.3.0",
+        "pure-color": "^1.2.0"
       }
     },
     "node_modules/react-colorful": {
@@ -20060,6 +20097,21 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-json-tree": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.11.2.tgz",
+      "integrity": "sha512-aYhUPj1y5jR3ZQ+G3N7aL8FbTyO03iLwnVvvEikLcNFqNTyabdljo9xDftZndUBFyyyL0aK3qGO9+8EilILHUw==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.6.1",
+        "prop-types": "^15.5.8",
+        "react-base16-styling": "^0.5.1"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0"
+      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -22177,6 +22229,20 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
+    },
+    "node_modules/storybook-formik": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/storybook-formik/-/storybook-formik-2.1.5.tgz",
+      "integrity": "sha512-vBrac3qzTinJdtCqy4MdrBeWxnQ5pY0Y2gKGv8VCwjw5ZY5IJc6nAVxP+nXTd0bciyEw8OLbrPwwpgVHCFdAZQ==",
+      "dev": true,
+      "dependencies": {
+        "react-json-tree": "^0.11.2"
+      },
+      "peerDependencies": {
+        "formik": "^1.0.0||^2.0.0",
+        "react": "*",
+        "react-dom": "*"
+      }
     },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
@@ -32213,6 +32279,12 @@
         }
       }
     },
+    "base16": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
+      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA=",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -39719,10 +39791,22 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.curry": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
+      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA=",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -42494,6 +42578,12 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "pure-color": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
+      "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=",
+      "dev": true
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -42630,6 +42720,18 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.7",
         "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "react-base16-styling": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.5.3.tgz",
+      "integrity": "sha1-OFjyTpxN2MvT9wLz901YHKKRcmk=",
+      "dev": true,
+      "requires": {
+        "base16": "^1.0.0",
+        "lodash.curry": "^4.0.1",
+        "lodash.flow": "^3.3.0",
+        "pure-color": "^1.2.0"
       }
     },
     "react-colorful": {
@@ -42877,6 +42979,17 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-json-tree": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/react-json-tree/-/react-json-tree-0.11.2.tgz",
+      "integrity": "sha512-aYhUPj1y5jR3ZQ+G3N7aL8FbTyO03iLwnVvvEikLcNFqNTyabdljo9xDftZndUBFyyyL0aK3qGO9+8EilILHUw==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.6.1",
+        "prop-types": "^15.5.8",
+        "react-base16-styling": "^0.5.1"
+      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -44714,6 +44827,15 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
+    },
+    "storybook-formik": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/storybook-formik/-/storybook-formik-2.1.5.tgz",
+      "integrity": "sha512-vBrac3qzTinJdtCqy4MdrBeWxnQ5pY0Y2gKGv8VCwjw5ZY5IJc6nAVxP+nXTd0bciyEw8OLbrPwwpgVHCFdAZQ==",
+      "dev": true,
+      "requires": {
+        "react-json-tree": "^0.11.2"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.2.1",
-    "storybook-formik": "^2.1.5"
+    "prettier": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "storybook-formik": "^2.1.5"
   }
 }

--- a/src/assets/spinner.svg
+++ b/src/assets/spinner.svg
@@ -1,0 +1,5 @@
+<svg class="spinner" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+    <rect class="spinner__rect" x="0" y="0" width="100" height="100" fill="none"></rect>
+    <circle class="spinner__circle" cx="50" cy="50" r="40" stroke="#999999" fill="none" stroke-width="6" stroke-linecap="round">
+    </circle>
+</svg>

--- a/src/components/atoms/Button/index.stories.tsx
+++ b/src/components/atoms/Button/index.stories.tsx
@@ -57,7 +57,7 @@ Default.args = {
 export const Secondary = Template.bind({});
 Secondary.args = {
   label: 'Cancel',
-  ariaLabel: 'Cancel removing crew member',
+  'aria-label': 'Cancel removing crew member',
   isPrimary: false,
   size: 'large',
 };
@@ -65,7 +65,7 @@ Secondary.args = {
 export const Warning = Template.bind({});
 Warning.args = {
   label: 'Delete',
-  ariaLabel: 'Remove crew member',
+  'aria-label': 'Remove crew member',
   isWarning: true,
   size: 'large',
 };
@@ -81,7 +81,7 @@ SmallWarning.args = {
 export const WithoutBorder = Template.bind({});
 WithoutBorder.args = {
   label: 'Back',
-  ariaLabel: 'Back to step 2',
+  'aria-label': 'Back to step 2',
   isPrimary: false,
   border: false,
 };
@@ -89,7 +89,7 @@ WithoutBorder.args = {
 export const WithPrimaryColor = Template.bind({});
 WithPrimaryColor.args = {
   label: 'Save',
-  ariaLabel: 'Save changes',
+  'aria-label': 'Save changes',
   size: 'verysmall',
   isPrimary: false,
   border: false,
@@ -101,7 +101,7 @@ WithPrimaryColor.args = {
 export const WithPrimaryColorAndBorder = Template.bind({});
 WithPrimaryColorAndBorder.args = {
   label: '+ Add',
-  ariaLabel: 'Add new service',
+  'aria-label': 'Add new service',
   size: 'medium',
   isPrimary: false,
   isBold: true,
@@ -118,7 +118,7 @@ IsLoading.args = {
 export const SignIn = Template.bind({});
 SignIn.args = {
   label: 'Sign in',
-  ariaLabel: 'Sign in to Voirsy',
+  'aria-label': 'Sign in to Voirsy',
   borderRadius: 50,
   fontSize: 2,
 };

--- a/src/components/atoms/Button/index.stories.tsx
+++ b/src/components/atoms/Button/index.stories.tsx
@@ -34,8 +34,8 @@ export default {
     isBold: {
       description: "When it's `true` `font-weight` is 700 otherwise 500",
     },
-    border: {
-      description: "When it's `true` `border` is 1px otherwise 0px",
+    borderWidth: {
+      description: "Value in px's",
     },
     isPrimaryColor: {
       description:
@@ -83,7 +83,7 @@ WithoutBorder.args = {
   label: 'Back',
   'aria-label': 'Back to step 2',
   isPrimary: false,
-  border: false,
+  borderWidth: 0,
 };
 
 export const WithPrimaryColor = Template.bind({});
@@ -92,7 +92,7 @@ WithPrimaryColor.args = {
   'aria-label': 'Save changes',
   size: 'verysmall',
   isPrimary: false,
-  border: false,
+  borderWidth: 0,
   isPrimaryColor: true,
   isBold: true,
   buttonWidth: 50,

--- a/src/components/atoms/Button/index.stories.tsx
+++ b/src/components/atoms/Button/index.stories.tsx
@@ -10,7 +10,8 @@ export default {
       description: 'Main label of the button',
     },
     isPrimary: {
-      description: "Font-size of button text given in rem's",
+      description:
+        "Determines that button should be primary. When isn't primary `background` is `transparent`, color of font and border take the primary color",
     },
     size: {
       control: 'select',

--- a/src/components/atoms/Button/index.stories.tsx
+++ b/src/components/atoms/Button/index.stories.tsx
@@ -28,13 +28,7 @@ export default {
       description: "Font-size of button text given in rem's",
     },
   },
-  decorators: [
-    (S) => (
-      <div style={{ width: '22rem', height: '3.8rem' }}>
-        <S />
-      </div>
-    ),
-  ],
+  decorators: [(S) => <div style={{ width: '22rem', height: '3.8rem' }}>{S()}</div>],
 } as Meta;
 
 const Template: Story<ButtonProps> = (args) => <Button {...args} />;

--- a/src/components/atoms/Button/index.stories.tsx
+++ b/src/components/atoms/Button/index.stories.tsx
@@ -6,15 +6,8 @@ export default {
   title: 'Components/Button',
   component: Button,
   argTypes: {
-    label: {
+    children: {
       description: 'Main label of the button',
-    },
-    isPrimary: {
-      description:
-        "Determines that button should be primary. When isn't primary `background` is `transparent`, color of font and border take the primary color",
-    },
-    size: {
-      control: 'select',
     },
     type: {
       control: 'select',
@@ -28,96 +21,101 @@ export default {
       },
       description: "Value in rem's",
     },
-    isWarning: {
-      description: "When it's `true` the primary color of the button is red",
-    },
     isBold: {
       description: "When it's `true` `font-weight` is 700 otherwise 500",
-    },
-    borderWidth: {
-      description: "Value in px's",
-    },
-    isPrimaryColor: {
-      description:
-        'Whenever the color of the text, border and icon should be purple. It should be pass only when button is not primary',
     },
     fontSize: {
       description: "Font-size of button text given in rem's",
     },
   },
+  decorators: [
+    (S) => (
+      <div style={{ width: '22rem', height: '3.8rem' }}>
+        <S />
+      </div>
+    ),
+  ],
 } as Meta;
 
 const Template: Story<ButtonProps> = (args) => <Button {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-  label: 'Add',
+  children: 'Add',
+  variant: 'contained',
+  width: 15,
 };
 
 export const Secondary = Template.bind({});
 Secondary.args = {
-  label: 'Cancel',
+  children: 'Cancel',
+  color: 'secondary',
+  variant: 'outlined',
+  height: 5,
+  width: 20,
+  borderRadius: 0.5,
   'aria-label': 'Cancel removing crew member',
-  isPrimary: false,
-  size: 'large',
 };
 
 export const Warning = Template.bind({});
 Warning.args = {
-  label: 'Delete',
+  children: 'Delete',
+  color: 'warning',
+  variant: 'contained',
+  height: 5,
+  width: 20,
+  borderRadius: 0.5,
   'aria-label': 'Remove crew member',
-  isWarning: true,
-  size: 'large',
 };
 
 export const SmallWarning = Template.bind({});
 SmallWarning.args = {
-  label: 'Delete salon',
-  isPrimary: false,
-  isWarning: true,
-  size: 'verysmall',
+  children: 'Delete salon',
+  color: 'warning',
+  variant: 'outlined',
+  height: 3,
+  width: 10,
+  borderRadius: 0.5,
 };
 
 export const WithoutBorder = Template.bind({});
 WithoutBorder.args = {
-  label: 'Back',
+  children: 'Back',
+  color: 'secondary',
+  width: 12,
   'aria-label': 'Back to step 2',
-  isPrimary: false,
-  borderWidth: 0,
 };
 
 export const WithPrimaryColor = Template.bind({});
 WithPrimaryColor.args = {
-  label: 'Save',
+  children: 'Save',
+  width: 6,
+  height: 3,
   'aria-label': 'Save changes',
-  size: 'verysmall',
-  isPrimary: false,
-  borderWidth: 0,
-  isPrimaryColor: true,
-  isBold: true,
-  buttonWidth: 50,
 };
 
 export const WithPrimaryColorAndBorder = Template.bind({});
 WithPrimaryColorAndBorder.args = {
-  label: '+ Add',
+  children: '+ Add',
+  variant: 'outlined',
   'aria-label': 'Add new service',
-  size: 'medium',
-  isPrimary: false,
-  isBold: true,
-  isPrimaryColor: true,
 };
 
 export const IsLoading = Template.bind({});
 IsLoading.args = {
-  label: '+ Add',
-  size: 'medium',
+  children: '+ Add',
   isLoading: true,
+  variant: 'contained',
+  color: 'secondary',
+  iconColor: 'lightblue',
 };
 
 export const SignIn = Template.bind({});
 SignIn.args = {
-  label: 'Sign in',
+  children: 'Sign in',
+  variant: 'contained',
+  width: 15,
+  height: 5,
   'aria-label': 'Sign in to Voirsy',
   borderRadius: 50,
   fontSize: 2,
@@ -125,6 +123,9 @@ SignIn.args = {
 
 export const IsSocial = Template.bind({});
 IsSocial.args = {
-  label: 'Continue with Google',
+  children: 'Continue with Google',
+  width: 30,
+  borderRadius: 50,
+  fontSize: 1.4,
   isSocial: true,
 };

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -17,7 +17,6 @@ const Button = ({
   buttonWidth = 0,
   isSocial = false,
   isLoading = false,
-  ariaLabel,
   fontSize,
   onClick = () => {},
 }: ButtonProps) => (
@@ -35,7 +34,7 @@ const Button = ({
     onClick={onClick}
     isSocial={isSocial}
     fontSize={fontSize}
-    aria-label={ariaLabel}
+    {...props}
   >
     {isLoading && (
       <BeatLoader

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -11,14 +11,14 @@ const Button = ({
   borderRadius = 1,
   isPrimary = true,
   isWarning = false,
-  border = true,
+  borderWidth = 1,
   isPrimaryColor = false,
   isBold = false,
   buttonWidth = 0,
   isSocial = false,
   isLoading = false,
   fontSize,
-  onClick = () => {},
+  ...props
 }: ButtonProps) => (
   <Styled.Button
     type={type}
@@ -26,12 +26,11 @@ const Button = ({
     borderRadius={isSocial ? 30 : borderRadius}
     isPrimary={isPrimary}
     isWarning={isWarning}
-    border={border}
+    borderWidth={borderWidth}
     isPrimaryColor={isPrimaryColor}
     isBold={isBold}
     buttonWidth={buttonWidth}
     isLoading={isLoading}
-    onClick={onClick}
     isSocial={isSocial}
     fontSize={fontSize}
     {...props}

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,48 +1,33 @@
-import { BeatLoader } from 'react-spinners';
 import { FcGoogle } from 'react-icons/fc';
 import { ButtonProps } from './types';
 import Styled from './styles';
-import theme from '../../../theme/theme';
+// import theme from '../../../theme/theme';
+import Spinner from '../Spinner';
 
 const Button = ({
-  label,
-  type = 'button',
-  size = 'small',
-  borderRadius = 1,
-  isPrimary = true,
-  isWarning = false,
-  borderWidth = 1,
-  isPrimaryColor = false,
-  isBold = false,
-  buttonWidth = 0,
+  children,
   isSocial = false,
   isLoading = false,
-  fontSize,
+  color = 'primary',
+  iconColor = 'black',
+  variant = 'default',
+  width,
+  height,
   ...props
 }: ButtonProps) => (
   <Styled.Button
-    type={type}
-    size={isSocial ? 'medium' : size}
-    borderRadius={isSocial ? 30 : borderRadius}
-    isPrimary={isPrimary}
-    isWarning={isWarning}
-    borderWidth={borderWidth}
-    isPrimaryColor={isPrimaryColor}
-    isBold={isBold}
-    buttonWidth={buttonWidth}
     isLoading={isLoading}
     isSocial={isSocial}
-    fontSize={fontSize}
+    color={isSocial ? 'social' : color}
+    variant={isSocial ? 'contained' : variant}
+    $width={width}
+    $height={isSocial && !height ? 4 : height}
+    disabled={isLoading}
     {...props}
   >
-    {isLoading && (
-      <BeatLoader
-        color={theme.colors.grayColors.dark}
-        size={size === 'small' || size === 'verysmall' ? 12 : 16}
-      />
-    )}
+    {isLoading && <Spinner size={height ? `calc(${height}rem * 0.75)` : '80%'} color={iconColor} />}
     {isSocial && <FcGoogle />}
-    {!isLoading && label}
+    {!isLoading && children}
   </Styled.Button>
 );
 

--- a/src/components/atoms/Button/styles.ts
+++ b/src/components/atoms/Button/styles.ts
@@ -6,7 +6,7 @@ const Button = styled.button<StyledButtonProps>`
   cursor: pointer;
   border-radius: ${({ borderRadius }) => `${borderRadius}rem`};
   border-style: solid;
-  border-width: ${({ border }) => (border ? '1px' : '0px')};
+  border-width: ${({ borderWidth }) => `${borderWidth}px`};
   font-weight: ${({ isBold }) => (isBold ? '700' : '500')};
   outline: none;
   transition: background-color 150ms ease-in-out;

--- a/src/components/atoms/Button/styles.ts
+++ b/src/components/atoms/Button/styles.ts
@@ -21,17 +21,18 @@ const Button = styled.button.attrs<StyledButtonProps>(({ $height, type }) => ({
     background-color: ${variant === 'contained'
       ? theme.colors[Colors[color]].normal
       : 'transparent'};
-    font-size: ${fontSize
-      ? `${fontSize}rem`
-      : updatedHeight?.includes('%')
-      ? '1.8rem'
-      : `calc(${updatedHeight} * 0.4)`};
+    font-size: ${updatedHeight?.includes('%') ? '1.8rem' : `calc(${updatedHeight} * 0.4)`};
     border-radius: ${borderRadius ? `${borderRadius}` : '1'}rem;
     border-width: ${variant === 'default' ? 0 : 1}px;
     border-color: ${theme.colors[Colors[color]].normal};
     color: ${variant === 'contained' ? theme.colors.white : theme.colors[Colors[color]].normal};
     width: ${$width ? `${$width}rem` : '100%'};
     height: ${updatedHeight};
+
+    ${fontSize &&
+    css`
+      font-size: ${fontSize}rem;
+    `}
 
     :hover:not(:disabled),
     :focus:not(:disabled) {

--- a/src/components/atoms/Button/styles.ts
+++ b/src/components/atoms/Button/styles.ts
@@ -11,7 +11,6 @@ const Button = styled.button.attrs<StyledButtonProps>(({ $height, type }) => ({
   cursor: pointer;
   border-style: solid;
   font-weight: 500;
-  outline: none;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/atoms/Button/styles.ts
+++ b/src/components/atoms/Button/styles.ts
@@ -1,154 +1,66 @@
+import hexToRgba from 'hex-rgba';
 import styled, { css } from 'styled-components';
+import { Colors } from '../../../types/global';
 import { StyledButtonProps } from './types';
 
-const Button = styled.button<StyledButtonProps>`
+const Button = styled.button.attrs<StyledButtonProps>(({ $height, type }) => ({
+  updatedHeight: $height ? `${$height}rem` : '100%',
+  type: type || 'button',
+}))<StyledButtonProps & { updatedHeight?: string }>`
   overflow: hidden;
   cursor: pointer;
-  border-radius: ${({ borderRadius }) => `${borderRadius}rem`};
   border-style: solid;
-  border-width: ${({ borderWidth }) => `${borderWidth}px`};
-  font-weight: ${({ isBold }) => (isBold ? '700' : '500')};
+  font-weight: 500;
   outline: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   transition: background-color 150ms ease-in-out;
 
-  ${({ size }) => {
-    if (size === 'verysmall')
-      return css`
-        height: 2.2rem;
-        width: 7rem;
-        font-size: 1rem;
+  ${({ theme, color, variant, $width, updatedHeight, borderRadius, fontSize }) => css`
+    background-color: ${variant === 'contained'
+      ? theme.colors[Colors[color]].normal
+      : 'transparent'};
+    font-size: ${fontSize
+      ? `${fontSize}rem`
+      : updatedHeight?.includes('%')
+      ? '1.8rem'
+      : `calc(${updatedHeight} * 0.4)`};
+    border-radius: ${borderRadius ? `${borderRadius}` : '1'}rem;
+    border-width: ${variant === 'default' ? 0 : 1}px;
+    border-color: ${theme.colors[Colors[color]].normal};
+    color: ${variant === 'contained' ? theme.colors.white : theme.colors[Colors[color]].normal};
+    width: ${$width ? `${$width}rem` : '100%'};
+    height: ${updatedHeight};
 
-        @media (min-width: ${({ theme }) => theme.breakpoints.tabletPortrait}) {
-          height: 2.8rem;
-          width: 9rem;
-          font-size: 1.1rem;
-        }
-      `;
-    if (size === 'small')
-      return css`
-        height: 2.8rem;
-        width: 9rem;
-        font-size: 1.1rem;
+    :hover:not(:disabled),
+    :focus:not(:disabled) {
+      background-color: ${variant === 'contained'
+        ? hexToRgba(theme.colors[Colors[color]].normal, 90)
+        : hexToRgba(theme.colors[Colors[color]].normal, 20)};
+    }
+  `};
 
-        @media (min-width: ${({ theme }) => theme.breakpoints.tabletPortrait}) {
-          height: 3.5rem;
-          width: 12rem;
-          font-size: 1.3rem;
-        }
-      `;
-    if (size === 'medium')
-      return css`
-        height: 3.5rem;
-        width: 20rem;
-        font-size: 1.2rem;
+  :disabled {
+    cursor: no-drop;
+  }
 
-        @media (min-width: ${({ theme }) => theme.breakpoints.tabletPortrait}) {
-          height: 4rem;
-          width: 25rem;
-          font-size: 1.3rem;
-        }
-      `;
-    return css`
-      height: 4rem;
-      width: 17rem;
-      font-size: 1.4rem;
-
-      @media (min-width: ${({ theme }) => theme.breakpoints.tabletPortrait}) {
-        height: 4.5rem;
-        width: 20rem;
-        font-size: 1.5rem;
-      }
-    `;
-  }}
-  ${({ theme, isPrimary, isPrimaryColor }) => {
-    if (!isPrimary)
-      return css`
-        border-color: ${isPrimaryColor ? theme.colors.purple.normal : theme.colors.grayColors.dark};
-        background-color: transparent;
-        color: ${isPrimaryColor ? theme.colors.purple.normal : theme.colors.grayColors.dark};
-
-        &:hover,
-        &:focus {
-          background-color: ${isPrimaryColor
-            ? theme.colors.purple._020
-            : theme.colors.grayColors.dark020};
-        }
-      `;
-    return css`
-      border: ${theme.colors.purple.normal};
-      background-color: ${theme.colors.purple.normal};
-      color: ${theme.colors.white};
-
-      &:hover,
-      &:focus {
-        background-color: ${theme.colors.purple._090};
-      }
-    `;
-  }};
-
-  ${({ theme, isWarning, isPrimary }) =>
-    isWarning &&
-    css`
-      background-color: ${isPrimary ? theme.colors.red.normal : 'transparent'};
-      border-color: ${theme.colors.red.normal};
-      color: ${isPrimary ? theme.colors.white : theme.colors.red.normal};
-
-      &:hover,
-      &:focus {
-        background-color: ${isPrimary ? theme.colors.red._080 : theme.colors.red._010};
-      }
-    `};
-
-  ${({ theme, isLoading }) =>
-    isLoading &&
-    css`
-      cursor: not-allowed;
-      background-color: ${theme.colors.grayColors.dark035};
-      border-color: ${theme.colors.grayColors.dark035};
-
-      & > span {
-        display: flex;
-        justify-content: center;
-      }
-
-      &:hover,
-      &:focus {
-        background-color: ${theme.colors.grayColors.dark035};
-        border-color: ${theme.colors.grayColors.dark035};
-      }
-    `};
-
-  ${({ theme, isSocial }) =>
+  ${({ theme, isSocial, updatedHeight }) =>
     isSocial &&
     css`
-      background-color: ${theme.colors.social};
-      border-color: ${theme.colors.social};
       position: relative;
 
-      & > svg {
+      > svg {
+        width: calc(${updatedHeight!} * 0.7);
+        height: calc(${updatedHeight!} * 0.7);
         background: ${theme.colors.white};
-        height: 2.6rem;
-        width: 2.6rem;
+        transform: translate(20%, -50%);
         position: absolute;
-        top: 7px;
-        left: 7px;
+        top: 50%;
+        left: 0;
         border-radius: 50%;
       }
-
-      &:hover,
-      &:focus {
-        background-color: ${theme.colors.social};
-        border-color: ${theme.colors.social};
-      }
-    `};
-
-  width: ${({ buttonWidth }) => buttonWidth !== 0 && `${buttonWidth}px !important`};
-
-  font-size: ${({ fontSize }) => fontSize && `${fontSize * 0.75}rem`};
-
-  @media (min-width: ${({ theme }) => theme.breakpoints.tabletPortrait}) {
-    font-size: ${({ fontSize }) => fontSize && `${fontSize}rem`};
-  }
+    `}
 `;
 
 const Styled = {

--- a/src/components/atoms/Button/types.ts
+++ b/src/components/atoms/Button/types.ts
@@ -5,7 +5,7 @@ export interface StyledButtonProps {
   isWarning?: boolean;
   size?: Size;
   borderRadius?: number;
-  border?: boolean;
+  borderWidth?: number;
   isPrimaryColor?: boolean;
   isBold?: boolean;
   buttonWidth?: number;

--- a/src/components/atoms/Button/types.ts
+++ b/src/components/atoms/Button/types.ts
@@ -1,22 +1,25 @@
-import { ButtonType, Size } from '../../../types/typeAliases';
+import { ButtonType, Color } from '../../../types/global';
 
-export interface StyledButtonProps {
-  isPrimary?: boolean;
-  isWarning?: boolean;
-  size?: Size;
+export interface SharedProps {
   borderRadius?: number;
-  borderWidth?: number;
-  isPrimaryColor?: boolean;
-  isBold?: boolean;
-  buttonWidth?: number;
   isLoading?: boolean;
   isSocial?: boolean;
   fontSize?: number;
+  color: Color;
+  iconColor?: Color;
+  variant: 'default' | 'outlined' | 'contained';
 }
 
-export interface ButtonProps extends StyledButtonProps {
-  label: string;
+export interface StyledButtonProps extends SharedProps {
+  $width?: number;
+  $height?: number;
+}
+
+export interface ButtonProps extends SharedProps {
+  children: string;
   type?: ButtonType;
+  width?: number;
+  height?: number;
   'aria-label'?: string;
-  onClick: () => void;
+  onClick?: () => void;
 }

--- a/src/components/atoms/Button/types.ts
+++ b/src/components/atoms/Button/types.ts
@@ -16,7 +16,7 @@ export interface StyledButtonProps {
 
 export interface ButtonProps extends StyledButtonProps {
   label: string;
-  ariaLabel?: string;
   type?: ButtonType;
+  'aria-label'?: string;
   onClick: () => void;
 }

--- a/src/components/atoms/Button/types.ts
+++ b/src/components/atoms/Button/types.ts
@@ -1,7 +1,9 @@
-export type StyledButtonProps = {
+import { ButtonType, Size } from '../../../types/typeAliases';
+
+export interface StyledButtonProps {
   isPrimary?: boolean;
   isWarning?: boolean;
-  size?: 'verysmall' | 'small' | 'medium' | 'large';
+  size?: Size;
   borderRadius?: number;
   border?: boolean;
   isPrimaryColor?: boolean;
@@ -10,11 +12,11 @@ export type StyledButtonProps = {
   isLoading?: boolean;
   isSocial?: boolean;
   fontSize?: number;
-};
+}
 
-export type ButtonProps = StyledButtonProps & {
+export interface ButtonProps extends StyledButtonProps {
   label: string;
   ariaLabel?: string;
-  type?: 'button' | 'submit' | 'reset';
+  type?: ButtonType;
   onClick: () => void;
-};
+}

--- a/src/components/atoms/Button/types.ts
+++ b/src/components/atoms/Button/types.ts
@@ -1,4 +1,4 @@
-import { ButtonType, Color } from '../../../types/global';
+import { ButtonType, ButtonVariant, Color } from '../../../types/global';
 
 export interface SharedProps {
   borderRadius?: number;
@@ -7,7 +7,7 @@ export interface SharedProps {
   fontSize?: number;
   color: Color;
   iconColor?: Color;
-  variant: 'default' | 'outlined' | 'contained';
+  variant: ButtonVariant;
 }
 
 export interface StyledButtonProps extends SharedProps {

--- a/src/components/atoms/IconButton/index.stories.tsx
+++ b/src/components/atoms/IconButton/index.stories.tsx
@@ -13,99 +13,110 @@ export default {
       control: 'select',
       defaultValue: 'button',
     },
+    size: {
+      description:
+        "Size of button given in rem's. When `size` isn't pass to component it will be adjust to parent component.",
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '100%' },
+      },
+    },
+    borderRadius: {
+      description: "Value in rem's",
+    },
+    variant: {
+      description: 'Variant of IconButton',
+    },
+    color: {
+      description: 'Primary color of IconButton',
+    },
     iconWidth: {
       description: "Stroke-width of icon given in px's",
     },
-    buttonSize: {
-      description: "Size of button given in rem's",
-    },
-    borderWidth: {
-      description: "Width of border given in px's",
-    },
     isAvatar: {
       description:
-        'When `isAvatar` is set to `true` IconButton comes in avatar mode and instead of icon it displays user avatar which have to be pass in avatarUrl. If avatarUrl has not been passed, default icon display.',
-    },
-    primaryColor: {
-      control: 'color',
-      description: 'Color of background when button is in primary mode. ',
+        'When `isAvatar` is set to `true` IconButton comes in avatar mode and instead of icon it displays user avatar which have to be pass in avatarUrl. If avatarUrl has not been passed, default icon is displaying.',
     },
     avatarUrl: {
       description: 'Link to user avatar stored on server.',
     },
-    icon: {
+    children: {
       description:
         "Icon imported from `react-icons`. If it's possible import only Feather(fi) icons to keep consistent look of icons.",
     },
   },
+  decorators: [(S) => <div style={{ width: '4rem', height: '4rem' }}>{S()}</div>],
 } as Meta;
 
 const Template: Story<IconButtonProps> = (args) => <IconButton {...args} />;
 
-export const Primary = Template.bind({});
-Primary.args = {
-  ariaLabel: 'Find my current location',
-  buttonSize: 3.8,
-  iconWidth: 0,
-  icon: <BiCurrentLocation style={{ fill: theme.colors.white }} />,
+export const Default = Template.bind({});
+Default.args = {
+  children: <FiCheck size="80%" />,
+  'aria-label': 'Confirm changes',
+  size: 3,
+  color: 'secondary',
+  iconWidth: 3,
+};
+
+export const Contained = Template.bind({});
+Contained.args = {
+  children: <BiCurrentLocation />,
+  'aria-label': 'Find my current location',
+  size: 3.5,
+  variant: 'contained',
+  iconWidth: 0.5,
 };
 
 export const Secondary = Template.bind({});
 Secondary.args = {
-  ariaLabel: 'Close sign up form',
-  isPrimary: false,
-  buttonSize: 8,
-  icon: <FiX size="50%" />,
+  children: <FiX size="50%" />,
+  'aria-label': 'Close sign up form',
+  size: 7,
+  variant: 'outlined',
+  color: 'secondary',
 };
 
-export const PrimarySmall = Template.bind({});
-PrimarySmall.args = {
-  ariaLabel: 'Go further',
-  buttonSize: 2.5,
-  iconWidth: 2.5,
-  icon: <FiArrowRight />,
-};
-
-export const WithoutBorder = Template.bind({});
-WithoutBorder.args = {
-  ariaLabel: 'Confirm changes',
-  isPrimary: false,
-  borderWidth: 0,
-  buttonSize: 3.2,
+export const SmallPrimary = Template.bind({});
+SmallPrimary.args = {
+  children: <FiArrowRight />,
+  'aria-label': 'Go further',
+  size: 2.5,
+  variant: 'contained',
   iconWidth: 3,
-  icon: <FiCheck size="100%" />,
 };
 
 export const Heart = Template.bind({});
 Heart.args = {
-  ariaLabel: 'Add to favorites',
-  isPrimary: false,
-  borderWidth: 0,
-  buttonSize: 2.4,
+  children: <FiHeart size="80%" color={theme.colors.grayColors.heartIcon} />,
+  'aria-label': 'Add to favorites',
+  size: 2.5,
+  color: 'secondary',
+  borderRadius: 0.5,
   iconWidth: 1,
-  icon: <FiHeart size="100%" />,
 };
 
 export const LargeCamera = Template.bind({});
 LargeCamera.args = {
-  ariaLabel: 'Add photo',
-  buttonSize: 10,
-  primaryColor: theme.colors.blueOutline.normal,
-  icon: <FiCamera size="40%" color={theme.colors.grayColors.dark} />,
+  children: <FiCamera size="40%" color={theme.colors.grayColors.dark} />,
+  'aria-label': 'Add photo',
+  size: 8,
+  variant: 'contained',
+  color: 'lightblue',
 };
 
 export const SmallCamera = Template.bind({});
 SmallCamera.args = {
-  ariaLabel: 'Update your profile photo',
-  buttonSize: 4,
-  primaryColor: theme.colors.grayColors.dark,
+  children: <FiCamera size="70%" />,
+  'aria-label': 'Update your profile photo',
+  variant: 'contained',
+  color: 'secondary',
   iconWidth: 1,
-  icon: <FiCamera size="70%" />,
 };
 
 export const WithAvatar = Template.bind({});
 WithAvatar.args = {
-  ariaLabel: 'Open menu',
+  'aria-label': 'Open menu',
   isAvatar: true,
   avatarUrl:
     'https://cdn.psychologytoday.com/sites/default/files/styles/article-inline-half-caption/public/field_blog_entry_images/2018-09/shutterstock_648907024.jpg?itok=0hb44OrI',
@@ -113,6 +124,6 @@ WithAvatar.args = {
 
 export const WithDefaultAvatar = Template.bind({});
 WithDefaultAvatar.args = {
-  ariaLabel: 'Open menu',
+  'aria-label': 'Open menu',
   isAvatar: true,
 };

--- a/src/components/atoms/IconButton/index.tsx
+++ b/src/components/atoms/IconButton/index.tsx
@@ -13,12 +13,11 @@ const IconButton = ({
   iconWidth = 2,
   primaryColor,
   icon = <FiUser size="65%" />,
-  ariaLabel,
   isAvatar = false,
   isAdjustedToParent = false,
   avatarUrl,
   onClick,
-  as,
+  ...rest
 }: IconButtonProps) => (
   <Styled.Button
     isPrimary={isPrimary}
@@ -29,11 +28,10 @@ const IconButton = ({
     iconColor={icon.props.color}
     isAvatar={isAvatar}
     avatarUrl={avatarUrl}
-    aria-label={ariaLabel}
     type={type}
     onClick={onClick}
     isAdjustedToParent={isAdjustedToParent}
-    as={as}
+    {...rest}
   >
     {((isAvatar && !avatarUrl) || !isAvatar) &&
       React.cloneElement(icon, {

--- a/src/components/atoms/IconButton/index.tsx
+++ b/src/components/atoms/IconButton/index.tsx
@@ -17,6 +17,8 @@ const IconButton = ({
   isAvatar = false,
   isAdjustedToParent = false,
   avatarUrl,
+  onClick,
+  as,
 }: IconButtonProps) => (
   <Styled.Button
     isPrimary={isPrimary}
@@ -29,7 +31,9 @@ const IconButton = ({
     avatarUrl={avatarUrl}
     aria-label={ariaLabel}
     type={type}
+    onClick={onClick}
     isAdjustedToParent={isAdjustedToParent}
+    as={as}
   >
     {((isAvatar && !avatarUrl) || !isAvatar) &&
       React.cloneElement(icon, {

--- a/src/components/atoms/IconButton/index.tsx
+++ b/src/components/atoms/IconButton/index.tsx
@@ -15,6 +15,7 @@ const IconButton = ({
   icon = <FiUser size="65%" />,
   ariaLabel,
   isAvatar = false,
+  isAdjustedToParent = false,
   avatarUrl,
 }: IconButtonProps) => (
   <Styled.Button
@@ -28,6 +29,7 @@ const IconButton = ({
     avatarUrl={avatarUrl}
     aria-label={ariaLabel}
     type={type}
+    isAdjustedToParent={isAdjustedToParent}
   >
     {((isAvatar && !avatarUrl) || !isAvatar) &&
       React.cloneElement(icon, {

--- a/src/components/atoms/IconButton/index.tsx
+++ b/src/components/atoms/IconButton/index.tsx
@@ -2,41 +2,36 @@ import React from 'react';
 import { FiUser } from 'react-icons/fi';
 import { IconButtonProps } from './types';
 import Styled from './styles';
+import { Colors } from '../../../types/global';
+import theme from '../../../theme/theme';
 
 const iconDefaultSize = '80%';
 
 const IconButton = ({
-  isPrimary = true,
-  buttonSize = 5,
-  borderWidth = 2,
-  type = 'button',
-  iconWidth = 2,
-  primaryColor,
-  icon = <FiUser size="65%" />,
+  children = <FiUser size="65%" />,
   isAvatar = false,
-  isAdjustedToParent = false,
   avatarUrl,
-  onClick,
+  color = 'primary',
+  variant = 'default',
+  size,
   ...rest
 }: IconButtonProps) => (
   <Styled.Button
-    isPrimary={isPrimary}
-    buttonSize={buttonSize}
-    borderWidth={borderWidth}
-    iconWidth={iconWidth}
-    primaryColor={primaryColor}
-    iconColor={icon.props.color}
     isAvatar={isAvatar}
     avatarUrl={avatarUrl}
-    type={type}
-    onClick={onClick}
-    isAdjustedToParent={isAdjustedToParent}
+    color={color}
+    variant={variant}
+    $size={size}
     {...rest}
   >
     {((isAvatar && !avatarUrl) || !isAvatar) &&
-      React.cloneElement(icon, {
-        size: icon.props.size ? icon.props.size : iconDefaultSize,
-        ...icon.props,
+      React.cloneElement(children, {
+        size: children.props.size ? children.props.size : iconDefaultSize,
+        color:
+          children.props.color || variant === 'contained'
+            ? theme.colors.white
+            : theme.colors[Colors[color]].normal,
+        ...children.props,
       })}
   </Styled.Button>
 );

--- a/src/components/atoms/IconButton/styles.ts
+++ b/src/components/atoms/IconButton/styles.ts
@@ -1,54 +1,49 @@
+import hexToRgba from 'hex-rgba';
 import styled, { css } from 'styled-components';
+import { Colors } from '../../../types/global';
 import { StyledIconButtonProps } from './types';
 
-const Button = styled.button.attrs<StyledIconButtonProps>(
-  ({ theme, primaryColor, isAvatar, borderWidth, isPrimary }) => ({
-    primaryColor: primaryColor || theme.colors.purple.normal,
-    borderWidth: isAvatar ? 0 : borderWidth,
-    isPrimary: isAvatar ? true : isPrimary,
-  })
-)<StyledIconButtonProps>`
+const Button = styled.button.attrs<StyledIconButtonProps>(({ type }) => ({
+  type: type || 'button',
+}))<StyledIconButtonProps>`
   border-radius: 50%;
   cursor: pointer;
-  display: grid;
-  place-items: center;
   border-style: solid;
-  border-width: ${({ borderWidth }) => `${borderWidth}px`};
-  ${({ isAdjustedToParent, buttonSize, theme }) => {
-    if (isAdjustedToParent)
-      return css`
-        width: 100%;
-        height: 100%;
-      `;
+  transition: background-color 150ms ease-in-out;
+  outline: none;
 
-    return css`
-      width: ${buttonSize! * 0.75}rem;
-      height: ${buttonSize! * 0.75}rem;
-      @media (min-width: ${theme.breakpoints.tabletPortrait}) {
-        width: ${buttonSize}rem;
-        height: ${buttonSize}rem;
-      }
-    `;
-  }}
+  ${({ theme, $size, color, variant, iconWidth = 2, isAvatar, avatarUrl, borderRadius }) => css`
+    background-color: ${
+      variant === 'contained' ? theme.colors[Colors[color]].normal : 'transparent'
+    };
+    border-radius: ${borderRadius ? `${borderRadius}rem` : '50%'};
+    border-width: ${variant === 'default' ? 0 : 2}px;
+    border-color: ${theme.colors[Colors[color]].normal};
+    width: ${$size ? `${$size}rem` : '100%'};
+    height: ${$size ? `${$size}rem` : '100%'};
 
-  background-color: ${({ primaryColor, isPrimary }) => (isPrimary ? primaryColor : 'transparent')};
+    :hover:not(:disabled),
+    :focus:not(:disabled) {
+      background-color: ${
+        variant === 'contained'
+          ? hexToRgba(theme.colors[Colors[color]].normal, 90)
+          : hexToRgba(theme.colors[Colors[color]].normal, 20)
+      };
+    }
 
-  border-color: ${({ primaryColor, isPrimary, theme }) =>
-    isPrimary ? primaryColor : theme.colors.grayColors.dark};
+    & svg {
+      stroke-width: ${iconWidth}px;
+    }
 
-  ${({ isAvatar, avatarUrl }) =>
-    isAvatar &&
-    avatarUrl &&
-    css`
-      background: url(${avatarUrl}) center no-repeat;
-      background-size: cover;
-    `};
-
-  & svg {
-    stroke-width: ${({ iconWidth }) => `${iconWidth}px`};
-    stroke: ${({ iconColor, isPrimary, theme }) =>
-      isPrimary ? iconColor || theme.colors.white : iconColor || theme.colors.grayColors.dark};
-  }
+    ${
+      isAvatar &&
+      avatarUrl &&
+      css`
+        background: url(${avatarUrl}) center no-repeat;
+        background-size: cover;
+      `
+    }};
+  `}
 `;
 
 const Styled = { Button };

--- a/src/components/atoms/IconButton/styles.ts
+++ b/src/components/atoms/IconButton/styles.ts
@@ -10,7 +10,6 @@ const Button = styled.button.attrs<StyledIconButtonProps>(({ type }) => ({
   cursor: pointer;
   border-style: solid;
   transition: background-color 150ms ease-in-out;
-  outline: none;
   display: grid;
   place-items: center;
 

--- a/src/components/atoms/IconButton/styles.ts
+++ b/src/components/atoms/IconButton/styles.ts
@@ -14,13 +14,22 @@ const Button = styled.button.attrs<StyledIconButtonProps>(
   place-items: center;
   border-style: solid;
   border-width: ${({ borderWidth }) => `${borderWidth}px`};
-  width: ${({ buttonSize }) => `${buttonSize * 0.75}rem`};
-  height: ${({ buttonSize }) => `${buttonSize * 0.75}rem`};
+  ${({ isAdjustedToParent, buttonSize, theme }) => {
+    if (isAdjustedToParent)
+      return css`
+        width: 100%;
+        height: 100%;
+      `;
 
-  @media (min-width: ${({ theme }) => theme.breakpoints.tabletPortrait}) {
-    width: ${({ buttonSize }) => `${buttonSize}rem`};
-    height: ${({ buttonSize }) => `${buttonSize}rem`};
-  }
+    return css`
+      width: ${buttonSize! * 0.75}rem;
+      height: ${buttonSize! * 0.75}rem;
+      @media (min-width: ${theme.breakpoints.tabletPortrait}) {
+        width: ${buttonSize}rem;
+        height: ${buttonSize}rem;
+      }
+    `;
+  }}
 
   background-color: ${({ primaryColor, isPrimary }) => (isPrimary ? primaryColor : 'transparent')};
 

--- a/src/components/atoms/IconButton/styles.ts
+++ b/src/components/atoms/IconButton/styles.ts
@@ -11,6 +11,8 @@ const Button = styled.button.attrs<StyledIconButtonProps>(({ type }) => ({
   border-style: solid;
   transition: background-color 150ms ease-in-out;
   outline: none;
+  display: grid;
+  place-items: center;
 
   ${({ theme, $size, color, variant, iconWidth = 2, isAvatar, avatarUrl, borderRadius }) => css`
     background-color: ${

--- a/src/components/atoms/IconButton/types.ts
+++ b/src/components/atoms/IconButton/types.ts
@@ -12,11 +12,9 @@ export interface SharedProps {
 }
 
 export interface IconButtonProps extends SharedProps {
-  ariaLabel: string;
   icon: JSX.Element;
   type?: ButtonType;
   onClick?: () => void;
-  as?: any;
 }
 
 export interface StyledIconButtonProps extends SharedProps {

--- a/src/components/atoms/IconButton/types.ts
+++ b/src/components/atoms/IconButton/types.ts
@@ -1,22 +1,22 @@
-import { ButtonType } from '../../../types/global';
+import { ButtonType, Color } from '../../../types/global';
 
 export interface SharedProps {
-  buttonSize?: number;
   iconWidth?: number;
-  borderWidth?: number;
-  isPrimary?: boolean;
-  primaryColor?: string;
   isAvatar?: boolean;
   avatarUrl?: string;
-  isAdjustedToParent?: boolean;
+  color: Color;
+  borderRadius: number;
+  variant: 'default' | 'outlined' | 'contained';
 }
 
 export interface IconButtonProps extends SharedProps {
-  icon: JSX.Element;
+  children: JSX.Element;
   type?: ButtonType;
+  size: number;
+  'aria-label': string;
   onClick?: () => void;
 }
 
 export interface StyledIconButtonProps extends SharedProps {
-  iconColor?: string;
+  $size: number;
 }

--- a/src/components/atoms/IconButton/types.ts
+++ b/src/components/atoms/IconButton/types.ts
@@ -1,4 +1,4 @@
-import { ButtonType, Color } from '../../../types/global';
+import { ButtonType, ButtonVariant, Color } from '../../../types/global';
 
 export interface SharedProps {
   iconWidth?: number;
@@ -6,7 +6,7 @@ export interface SharedProps {
   avatarUrl?: string;
   color: Color;
   borderRadius: number;
-  variant: 'default' | 'outlined' | 'contained';
+  variant: ButtonVariant;
 }
 
 export interface IconButtonProps extends SharedProps {

--- a/src/components/atoms/IconButton/types.ts
+++ b/src/components/atoms/IconButton/types.ts
@@ -4,19 +4,20 @@ export interface SharedProps {
   iconWidth?: number;
   isAvatar?: boolean;
   avatarUrl?: string;
-  color: Color;
-  borderRadius: number;
-  variant: ButtonVariant;
+  borderRadius?: number;
+  variant?: ButtonVariant;
 }
 
 export interface IconButtonProps extends SharedProps {
   children: JSX.Element;
   type?: ButtonType;
-  size: number;
+  size?: number;
+  color?: Color;
   'aria-label': string;
   onClick?: () => void;
 }
 
 export interface StyledIconButtonProps extends SharedProps {
-  $size: number;
+  $size?: number;
+  color: Color;
 }

--- a/src/components/atoms/IconButton/types.ts
+++ b/src/components/atoms/IconButton/types.ts
@@ -1,4 +1,4 @@
-import { ButtonType } from '../../../types/typeAliases';
+import { ButtonType } from '../../../types/global';
 
 export interface SharedProps {
   buttonSize?: number;

--- a/src/components/atoms/IconButton/types.ts
+++ b/src/components/atoms/IconButton/types.ts
@@ -1,19 +1,22 @@
 export type SharedProps = {
-  buttonSize: number;
-  iconWidth: number;
-  borderWidth: number;
-  isPrimary: boolean;
+  buttonSize?: number;
+  iconWidth?: number;
+  borderWidth?: number;
+  isPrimary?: boolean;
   primaryColor?: string;
-  isAvatar: boolean;
+  isAvatar?: boolean;
   avatarUrl?: string;
+  isAdjustedToParent?: boolean;
 };
 
 export type IconButtonProps = SharedProps & {
   ariaLabel: string;
   icon: JSX.Element;
-  type: 'button' | 'submit' | 'reset';
+  type?: 'button' | 'submit' | 'reset';
+  onClick?: () => void;
+  as?: any;
 };
 
 export type StyledIconButtonProps = SharedProps & {
-  iconColor: string;
+  iconColor?: string;
 };

--- a/src/components/atoms/IconButton/types.ts
+++ b/src/components/atoms/IconButton/types.ts
@@ -1,4 +1,6 @@
-export type SharedProps = {
+import { ButtonType } from '../../../types/typeAliases';
+
+export interface SharedProps {
   buttonSize?: number;
   iconWidth?: number;
   borderWidth?: number;
@@ -7,16 +9,16 @@ export type SharedProps = {
   isAvatar?: boolean;
   avatarUrl?: string;
   isAdjustedToParent?: boolean;
-};
+}
 
-export type IconButtonProps = SharedProps & {
+export interface IconButtonProps extends SharedProps {
   ariaLabel: string;
   icon: JSX.Element;
-  type?: 'button' | 'submit' | 'reset';
+  type?: ButtonType;
   onClick?: () => void;
   as?: any;
-};
+}
 
-export type StyledIconButtonProps = SharedProps & {
+export interface StyledIconButtonProps extends SharedProps {
   iconColor?: string;
-};
+}

--- a/src/components/atoms/Input/index.tsx
+++ b/src/components/atoms/Input/index.tsx
@@ -44,28 +44,27 @@ const Input = ({
               aria-controls={!isEmail && name}
               aria-expanded={!isEmail && isPasswordVisible}
               aria-label="Show password"
-              icon={
-                isPasswordVisible ? (
-                  <FiEye color={theme.colors.grayColors.light} />
-                ) : (
-                  <FiEyeOff color={theme.colors.grayColors.light} />
-                )
-              }
-              isPrimary={false}
-              borderWidth={0}
-              buttonSize={inputHeight * 0.8}
+              size={inputHeight * 0.75}
               iconWidth={1}
               onClick={changePasswordVisibility}
-              isAdjustedToParent
-            />
+              color="secondary"
+            >
+              {isPasswordVisible ? (
+                <FiEye size="60%" color={theme.colors.grayColors.light} />
+              ) : (
+                <FiEyeOff size="60%" color={theme.colors.grayColors.light} />
+              )}
+            </IconButton>
           ) : (
             <IconButton
               aria-label="Go next"
-              icon={<FiArrowRight color={theme.colors.white} />}
-              buttonSize={inputHeight * 0.8}
+              size={inputHeight * 0.6}
               onClick={() => {}}
-              isAdjustedToParent
-            />
+              variant="contained"
+              iconWidth={3}
+            >
+              <FiArrowRight size="80%" color={theme.colors.white} />
+            </IconButton>
           )}
         </Styled.ButtonWrapper>
       )}

--- a/src/components/atoms/Input/index.tsx
+++ b/src/components/atoms/Input/index.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { FiArrowRight, FiEye, FiEyeOff } from 'react-icons/fi';
+import { InputProps } from './types';
+import Styled from './styles';
+import IconButton from '../IconButton';
+import theme from '../../../theme/theme';
+
+const Input = ({
+  variant = 'default',
+  type = 'text',
+  inputHeight = 3.5,
+  inputWidth = 30,
+  isPassword = false,
+  isEmail = false,
+  disabled = false,
+  ...rest
+}: InputProps) => {
+  const [isPasswordVisible, setPasswordVisibility] = useState(false);
+
+  const changePasswordVisibility = () => {
+    setPasswordVisibility((prevState) => !prevState);
+  };
+
+  return (
+    <Styled.InputWrapper>
+      <Styled.Input
+        type={isPassword ? (isPasswordVisible ? 'text' : 'password') : type}
+        variant={variant}
+        inputHeight={inputHeight}
+        inputWidth={inputWidth}
+        disabled={disabled}
+        {...rest}
+      />
+      <Styled.ButtonWrapper inputHeight={inputHeight}>
+        {(isPassword || isEmail) && (
+          <IconButton
+            icon={
+              isEmail ? (
+                <FiArrowRight color={theme.colors.white} />
+              ) : isPasswordVisible ? (
+                <FiEye color={theme.colors.grayColors.light} />
+              ) : (
+                <FiEyeOff color={theme.colors.grayColors.light} />
+              )
+            }
+            ariaLabel={isEmail ? 'Go next' : 'Show password'}
+            isPrimary={isEmail}
+            borderWidth={isEmail ? 1 : 0}
+            buttonSize={inputHeight * 0.8}
+            iconWidth={isEmail ? 2 : 1}
+            onClick={isEmail ? () => {} : changePasswordVisibility}
+            isAdjustedToParent
+          />
+        )}
+      </Styled.ButtonWrapper>
+    </Styled.InputWrapper>
+  );
+};
+
+export default Input;

--- a/src/components/atoms/Input/index.tsx
+++ b/src/components/atoms/Input/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FiArrowRight, FiEye, FiEyeOff } from 'react-icons/fi';
+import { FiArrowRight, FiEye, FiEyeOff, FiSearch } from 'react-icons/fi';
 import { InputProps } from './types';
 import Styled from './styles';
 import IconButton from '../IconButton';
@@ -23,6 +23,11 @@ const Input = ({
 
   return (
     <Styled.InputWrapper>
+      {variant === 'search' && (
+        <Styled.IconWrapper inputHeight={inputHeight}>
+          <FiSearch />
+        </Styled.IconWrapper>
+      )}
       <Styled.Input
         type={isPassword ? (isPasswordVisible ? 'text' : 'password') : type}
         variant={variant}

--- a/src/components/atoms/Input/index.tsx
+++ b/src/components/atoms/Input/index.tsx
@@ -6,6 +6,7 @@ import IconButton from '../IconButton';
 import theme from '../../../theme/theme';
 
 const Input = ({
+  name,
   variant = 'default',
   type = 'text',
   inputHeight = 3.5,
@@ -36,28 +37,38 @@ const Input = ({
         disabled={disabled}
         {...rest}
       />
-      <Styled.ButtonWrapper inputHeight={inputHeight}>
-        {(isPassword || isEmail) && (
-          <IconButton
-            icon={
-              isEmail ? (
-                <FiArrowRight color={theme.colors.white} />
-              ) : isPasswordVisible ? (
-                <FiEye color={theme.colors.grayColors.light} />
-              ) : (
-                <FiEyeOff color={theme.colors.grayColors.light} />
-              )
-            }
-            ariaLabel={isEmail ? 'Go next' : 'Show password'}
-            isPrimary={isEmail}
-            borderWidth={isEmail ? 1 : 0}
-            buttonSize={inputHeight * 0.8}
-            iconWidth={isEmail ? 2 : 1}
-            onClick={isEmail ? () => {} : changePasswordVisibility}
-            isAdjustedToParent
-          />
-        )}
-      </Styled.ButtonWrapper>
+      {(isPassword || isEmail) && (
+        <Styled.ButtonWrapper inputHeight={inputHeight}>
+          {isPassword ? (
+            <IconButton
+              aria-controls={!isEmail && name}
+              aria-expanded={!isEmail && isPasswordVisible}
+              aria-label="Show password"
+              icon={
+                isPasswordVisible ? (
+                  <FiEye color={theme.colors.grayColors.light} />
+                ) : (
+                  <FiEyeOff color={theme.colors.grayColors.light} />
+                )
+              }
+              isPrimary={false}
+              borderWidth={0}
+              buttonSize={inputHeight * 0.8}
+              iconWidth={1}
+              onClick={changePasswordVisibility}
+              isAdjustedToParent
+            />
+          ) : (
+            <IconButton
+              aria-label="Go next"
+              icon={<FiArrowRight color={theme.colors.white} />}
+              buttonSize={inputHeight * 0.8}
+              onClick={() => {}}
+              isAdjustedToParent
+            />
+          )}
+        </Styled.ButtonWrapper>
+      )}
     </Styled.InputWrapper>
   );
 };

--- a/src/components/atoms/Input/styles.ts
+++ b/src/components/atoms/Input/styles.ts
@@ -1,0 +1,51 @@
+import styled, { css } from 'styled-components';
+import { StyledButtonWrapperProps, StyledInputProps } from './types';
+
+const Input = styled.input.attrs<StyledInputProps>(({ variant }) => ({
+  borderRadius: variant === 'login' || variant === 'search' ? 5 : variant === 'default' ? 1 : 0.5,
+}))<StyledInputProps & { borderRadius?: string }>`
+  border-radius: ${({ borderRadius }) => `${borderRadius}rem`};
+  width: ${({ inputWidth }) => `${inputWidth}rem`};
+  height: ${({ inputHeight }) => `${inputHeight}rem`};
+  outline: none;
+
+  ${({ variant, theme }) => css`
+    border: ${variant === 'search' ? '0' : '1px'} solid ${theme.colors.blueOutline.normal};
+    padding: ${variant === 'login' ? '0 0 0 1.2rem' : '0 0.7rem'};
+    font-size: ${variant === 'login' ? '1.3' : '1.6'}rem;
+    background: ${variant === 'search' ? theme.colors.blueOutline._030 : theme.colors.white};
+
+    ::placeholder {
+      color: ${variant === 'login'
+        ? theme.colors.grayColors.light063
+        : theme.colors.grayColors.dark};
+    }
+
+    :disabled {
+      background-color: ${theme.colors.blueOutline._050};
+      border: 0;
+      color: ${theme.colors.grayColors.dark};
+    }
+  `}
+`;
+
+const InputWrapper = styled.div`
+  position: relative;
+  width: fit-content;
+`;
+
+const ButtonWrapper = styled.div.attrs<StyledButtonWrapperProps>(({ inputHeight }) => ({
+  height: inputHeight! * 0.6,
+}))<StyledButtonWrapperProps & { height?: number }>`
+  position: absolute;
+  ${({ inputHeight, height }) => css`
+    height: ${height}rem;
+    width: ${height}rem;
+    top: ${(inputHeight! - height!) / 2}rem;
+    right: ${(inputHeight! - height!) / 2}rem;
+  `}
+`;
+
+const Styled = { Input, InputWrapper, ButtonWrapper };
+
+export default Styled;

--- a/src/components/atoms/Input/styles.ts
+++ b/src/components/atoms/Input/styles.ts
@@ -10,7 +10,8 @@ const Input = styled.input.attrs<StyledInputProps>(({ variant }) => ({
   outline: none;
 
   ${({ variant, theme, inputHeight }) => css`
-    border: ${variant === 'search' ? '0' : '1px'} solid ${theme.colors.blueOutline.normal};
+    border: ${variant === 'search' ? '0' : '1px'} solid
+      ${variant === 'login' ? theme.colors.grayColors.light : theme.colors.blueOutline.normal};
     padding: ${variant === 'login'
       ? '0 0 0 1.2rem'
       : variant === 'search'

--- a/src/components/atoms/Input/styles.ts
+++ b/src/components/atoms/Input/styles.ts
@@ -7,16 +7,18 @@ const Input = styled.input.attrs<StyledInputProps>(({ variant }) => ({
   border-radius: ${({ borderRadius }) => `${borderRadius}rem`};
   width: ${({ inputWidth }) => `${inputWidth}rem`};
   height: ${({ inputHeight }) => `${inputHeight}rem`};
-  outline: none;
+  padding: 0 0.7rem 0 0;
 
   ${({ variant, theme, inputHeight }) => css`
     border: ${variant === 'search' ? '0' : '1px'} solid
       ${variant === 'login' ? theme.colors.grayColors.light : theme.colors.blueOutline.normal};
-    padding: ${variant === 'login'
-      ? '0 0 0 1.2rem'
-      : variant === 'search'
-      ? `0 0.7rem 0 ${inputHeight}rem`
-      : '0 0.7rem'};
+    padding-left: ${variant === 'login' ? '1.2rem' : '0.7rem'};
+
+    ${variant === 'search' &&
+    css`
+      padding-left: ${inputHeight}rem;
+    `}
+
     font-size: ${variant === 'login' ? '1.3' : '1.6'}rem;
     background: ${variant === 'search' ? theme.colors.blueOutline._030 : theme.colors.white};
     transition: background-color 100ms ease-in-out, border-color 100ms ease-in-out;

--- a/src/components/atoms/Input/styles.ts
+++ b/src/components/atoms/Input/styles.ts
@@ -63,15 +63,17 @@ const IconWrapper = styled.div<StyledButtonWrapperProps>`
   }
 `;
 
-const ButtonWrapper = styled.div.attrs<StyledButtonWrapperProps>(({ inputHeight }) => ({
-  height: inputHeight! * 0.6,
-}))<StyledButtonWrapperProps & { height?: number }>`
+const ButtonWrapper = styled.div<StyledButtonWrapperProps>`
   position: absolute;
-  ${({ inputHeight, height }) => css`
-    height: ${height}rem;
-    width: ${height}rem;
-    top: ${(inputHeight! - height!) / 2}rem;
-    right: ${(inputHeight! - height!) / 2}rem;
+  background-color: transparent;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  top: 0;
+  right: 0;
+  ${({ inputHeight }) => css`
+    height: ${inputHeight}rem;
+    width: ${inputHeight}rem;
   `}
 `;
 

--- a/src/components/atoms/Input/styles.ts
+++ b/src/components/atoms/Input/styles.ts
@@ -9,9 +9,13 @@ const Input = styled.input.attrs<StyledInputProps>(({ variant }) => ({
   height: ${({ inputHeight }) => `${inputHeight}rem`};
   outline: none;
 
-  ${({ variant, theme }) => css`
+  ${({ variant, theme, inputHeight }) => css`
     border: ${variant === 'search' ? '0' : '1px'} solid ${theme.colors.blueOutline.normal};
-    padding: ${variant === 'login' ? '0 0 0 1.2rem' : '0 0.7rem'};
+    padding: ${variant === 'login'
+      ? '0 0 0 1.2rem'
+      : variant === 'search'
+      ? `0 0.7rem 0 ${inputHeight}rem`
+      : '0 0.7rem'};
     font-size: ${variant === 'login' ? '1.3' : '1.6'}rem;
     background: ${variant === 'search' ? theme.colors.blueOutline._030 : theme.colors.white};
 
@@ -34,6 +38,22 @@ const InputWrapper = styled.div`
   width: fit-content;
 `;
 
+const IconWrapper = styled.div<StyledButtonWrapperProps>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: ${({ inputHeight }) => `${inputHeight}rem`};
+  width: ${({ inputHeight }) => `${inputHeight}rem`};
+  display: grid;
+  place-items: center;
+
+  & > svg {
+    width: 65%;
+    height: 65%;
+    stroke: ${({ theme }) => theme.colors.grayColors.dark};
+  }
+`;
+
 const ButtonWrapper = styled.div.attrs<StyledButtonWrapperProps>(({ inputHeight }) => ({
   height: inputHeight! * 0.6,
 }))<StyledButtonWrapperProps & { height?: number }>`
@@ -46,6 +66,6 @@ const ButtonWrapper = styled.div.attrs<StyledButtonWrapperProps>(({ inputHeight 
   `}
 `;
 
-const Styled = { Input, InputWrapper, ButtonWrapper };
+const Styled = { Input, InputWrapper, ButtonWrapper, IconWrapper };
 
 export default Styled;

--- a/src/components/atoms/Input/styles.ts
+++ b/src/components/atoms/Input/styles.ts
@@ -19,6 +19,7 @@ const Input = styled.input.attrs<StyledInputProps>(({ variant }) => ({
       : '0 0.7rem'};
     font-size: ${variant === 'login' ? '1.3' : '1.6'}rem;
     background: ${variant === 'search' ? theme.colors.blueOutline._030 : theme.colors.white};
+    transition: background-color 100ms ease-in-out, border-color 100ms ease-in-out;
 
     ::placeholder {
       color: ${variant === 'login'
@@ -30,6 +31,13 @@ const Input = styled.input.attrs<StyledInputProps>(({ variant }) => ({
       background-color: ${theme.colors.blueOutline._050};
       border: 0;
       color: ${theme.colors.grayColors.dark};
+    }
+
+    :hover:not(:disabled),
+    :focus {
+      background-color: ${variant !== 'search'
+        ? theme.colors.blueOutline._030
+        : theme.colors.blueOutline._050};
     }
   `}
 `;

--- a/src/components/atoms/Input/types.ts
+++ b/src/components/atoms/Input/types.ts
@@ -1,0 +1,18 @@
+export type StyledButtonWrapperProps = {
+  inputHeight?: number;
+};
+
+export type StyledInputProps = StyledButtonWrapperProps & {
+  variant?: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
+  inputWidth?: number;
+};
+
+export type InputProps = StyledInputProps & {
+  id: string;
+  value?: string;
+  type?: 'text' | 'password' | 'email' | 'search';
+  disabled?: boolean;
+  placeholder?: string;
+  isPassword?: boolean;
+  isEmail?: boolean;
+};

--- a/src/components/atoms/Input/types.ts
+++ b/src/components/atoms/Input/types.ts
@@ -1,10 +1,10 @@
 export type StyledButtonWrapperProps = {
-  inputHeight?: number;
+  inputHeight: number;
 };
 
 export type StyledInputProps = StyledButtonWrapperProps & {
   variant?: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
-  inputWidth?: number;
+  inputWidth: number;
 };
 
 export type InputProps = StyledInputProps & {

--- a/src/components/atoms/Input/types.ts
+++ b/src/components/atoms/Input/types.ts
@@ -1,17 +1,19 @@
-export type StyledButtonWrapperProps = {
+import { InputType, Variant } from '../../../types/typeAliases';
+
+export interface StyledButtonWrapperProps {
   inputHeight: number;
-};
+}
 
-export type StyledInputProps = StyledButtonWrapperProps & {
-  variant?: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
+export interface StyledInputProps extends StyledButtonWrapperProps {
+  variant?: Variant;
   inputWidth: number;
-};
+}
 
-export type InputProps = StyledInputProps & {
+export interface InputProps extends StyledInputProps {
   id: string;
-  type?: 'text' | 'password' | 'email' | 'search';
+  type?: InputType;
   disabled?: boolean;
   placeholder?: string;
   isPassword?: boolean;
   isEmail?: boolean;
-};
+}

--- a/src/components/atoms/Input/types.ts
+++ b/src/components/atoms/Input/types.ts
@@ -9,7 +9,6 @@ export type StyledInputProps = StyledButtonWrapperProps & {
 
 export type InputProps = StyledInputProps & {
   id: string;
-  value?: string;
   type?: 'text' | 'password' | 'email' | 'search';
   disabled?: boolean;
   placeholder?: string;

--- a/src/components/atoms/Input/types.ts
+++ b/src/components/atoms/Input/types.ts
@@ -1,4 +1,4 @@
-import { InputType, Variant } from '../../../types/typeAliases';
+import { InputType, Variant } from '../../../types/global';
 
 export interface StyledButtonWrapperProps {
   inputHeight: number;

--- a/src/components/atoms/Input/types.ts
+++ b/src/components/atoms/Input/types.ts
@@ -11,6 +11,7 @@ export interface StyledInputProps extends StyledButtonWrapperProps {
 
 export interface InputProps extends StyledInputProps {
   id: string;
+  name: string;
   type?: InputType;
   disabled?: boolean;
   placeholder?: string;

--- a/src/components/atoms/Label/index.tsx
+++ b/src/components/atoms/Label/index.tsx
@@ -1,0 +1,20 @@
+import Styled from './styles';
+import { LabelProps } from './types';
+
+const Label = ({ variant = 'default', children, inputValue, htmlFor, inputHeight }: LabelProps) => (
+  <Styled.Label
+    variant={variant}
+    inputValue={inputValue}
+    htmlFor={htmlFor}
+    inputHeight={inputHeight}
+    className={`${
+      variant === 'login' || variant === 'placeholder' || variant === 'search'
+        ? 'visually-hidden'
+        : ''
+    }`}
+  >
+    {children}
+  </Styled.Label>
+);
+
+export default Label;

--- a/src/components/atoms/Label/index.tsx
+++ b/src/components/atoms/Label/index.tsx
@@ -1,8 +1,16 @@
 import Styled from './styles';
 import { LabelProps } from './types';
 
-const Label = ({ variant = 'default', children, inputValue, htmlFor, inputHeight }: LabelProps) => (
+const Label = ({
+  variant = 'default',
+  children,
+  inputValue,
+  htmlFor,
+  inputHeight,
+  type,
+}: LabelProps) => (
   <Styled.Label
+    type={type}
     variant={variant}
     inputValue={inputValue}
     htmlFor={htmlFor}

--- a/src/components/atoms/Label/index.tsx
+++ b/src/components/atoms/Label/index.tsx
@@ -8,21 +8,24 @@ const Label = ({
   htmlFor,
   inputHeight,
   type,
-}: LabelProps) => (
-  <Styled.Label
-    type={type}
-    variant={variant}
-    inputValue={inputValue}
-    htmlFor={htmlFor}
-    inputHeight={inputHeight}
-    className={`${
-      variant === 'login' || variant === 'placeholder' || variant === 'search'
-        ? 'visually-hidden'
-        : ''
-    }`}
-  >
-    {children}
-  </Styled.Label>
-);
+}: LabelProps) => {
+  const labelClass =
+    variant === 'login' || variant === 'placeholder' || variant === 'search'
+      ? 'visually-hidden'
+      : '';
+
+  return (
+    <Styled.Label
+      type={type}
+      variant={variant}
+      inputValue={inputValue}
+      htmlFor={htmlFor}
+      inputHeight={inputHeight}
+      className={labelClass}
+    >
+      {children}
+    </Styled.Label>
+  );
+};
 
 export default Label;

--- a/src/components/atoms/Label/styles.ts
+++ b/src/components/atoms/Label/styles.ts
@@ -1,0 +1,40 @@
+import styled, { css } from 'styled-components';
+import { StyledLabelProps } from './types';
+
+const Label = styled.label<StyledLabelProps>`
+  font-weight: 400;
+  font-family: ${({ theme, variant }) =>
+    variant !== 'withDisable' ? theme.fonts.montserrat : theme.fonts.roboto};
+  color: ${({ theme }) => theme.colors.grayColors.dark};
+  font-size: 1.5rem;
+  padding-bottom: 0.5rem;
+
+  &.visually-hidden {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  ${({ inputValue, theme, inputHeight, variant }) =>
+    variant === 'animate' &&
+    css`
+      cursor: auto;
+      padding: 0 0.2rem;
+      z-index: 2;
+      position: absolute;
+      top: 0;
+      left: 1.2rem;
+      background: ${theme.colors.white};
+      transform: scale(${inputValue ? '0.8' : '1'})
+        translateY(${inputValue ? '-60%' : `calc(${inputHeight}rem / 2 - 50%)`});
+      transform-origin: 0;
+      transition: transform 0.2s ease;
+    `}
+`;
+const Styled = { Label };
+
+export default Styled;

--- a/src/components/atoms/Label/styles.ts
+++ b/src/components/atoms/Label/styles.ts
@@ -1,7 +1,10 @@
 import styled, { css } from 'styled-components';
 import { StyledLabelProps } from './types';
 
-const Label = styled.label<StyledLabelProps>`
+const Label = styled.label.attrs<StyledLabelProps>(({ type, inputHeight }) => ({
+  percentages: type === 'textarea' ? 0 : 50,
+  positionFromTop: type === 'textarea' ? 1.2 : inputHeight / 2,
+}))<StyledLabelProps>`
   font-weight: 400;
   font-family: ${({ theme, variant }) =>
     variant !== 'withDisable' ? theme.fonts.montserrat : theme.fonts.roboto};
@@ -19,7 +22,7 @@ const Label = styled.label<StyledLabelProps>`
     width: 1px;
   }
 
-  ${({ inputValue, theme, inputHeight, variant, type }) =>
+  ${({ inputValue, theme, variant, percentages, positionFromTop }) =>
     variant === 'animate' &&
     css`
       cursor: auto;
@@ -30,13 +33,7 @@ const Label = styled.label<StyledLabelProps>`
       left: 1.2rem;
       background: ${theme.colors.white};
       transform: scale(${inputValue ? '0.8' : '1'})
-        translateY(
-          ${inputValue
-            ? '-60%'
-            : `calc(${type === 'textarea' ? 1.2 : inputHeight / 2}rem - ${
-                type === 'textarea' ? 0 : 50
-              }%)`}
-        );
+        translateY(${inputValue ? '-60%' : `calc(${positionFromTop}rem - ${percentages}%)`});
       transform-origin: 0;
       transition: transform 0.2s ease;
     `}

--- a/src/components/atoms/Label/styles.ts
+++ b/src/components/atoms/Label/styles.ts
@@ -19,7 +19,7 @@ const Label = styled.label<StyledLabelProps>`
     width: 1px;
   }
 
-  ${({ inputValue, theme, inputHeight, variant }) =>
+  ${({ inputValue, theme, inputHeight, variant, type }) =>
     variant === 'animate' &&
     css`
       cursor: auto;
@@ -30,7 +30,13 @@ const Label = styled.label<StyledLabelProps>`
       left: 1.2rem;
       background: ${theme.colors.white};
       transform: scale(${inputValue ? '0.8' : '1'})
-        translateY(${inputValue ? '-60%' : `calc(${inputHeight}rem / 2 - 50%)`});
+        translateY(
+          ${inputValue
+            ? '-60%'
+            : `calc(${type === 'textarea' ? 1.2 : inputHeight / 2}rem - ${
+                type === 'textarea' ? 0 : 50
+              }%)`}
+        );
       transform-origin: 0;
       transition: transform 0.2s ease;
     `}

--- a/src/components/atoms/Label/types.ts
+++ b/src/components/atoms/Label/types.ts
@@ -1,4 +1,4 @@
-import { InputType, Variant } from '../../../types/typeAliases';
+import { InputType, Variant } from '../../../types/global';
 
 export interface StyledLabelProps {
   type: InputType;

--- a/src/components/atoms/Label/types.ts
+++ b/src/components/atoms/Label/types.ts
@@ -1,0 +1,10 @@
+export type StyledLabelProps = {
+  variant: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
+  inputValue: string;
+  inputHeight: number;
+};
+
+export type LabelProps = StyledLabelProps & {
+  children: string;
+  htmlFor: string;
+};

--- a/src/components/atoms/Label/types.ts
+++ b/src/components/atoms/Label/types.ts
@@ -1,10 +1,15 @@
 import { InputType, Variant } from '../../../types/global';
 
-export interface StyledLabelProps {
+interface SharedProps {
   type: InputType;
   variant: Variant;
   inputValue: string;
   inputHeight: number;
+}
+
+export interface StyledLabelProps extends SharedProps {
+  percentages?: number;
+  positionFromTop?: number;
 }
 
 export interface LabelProps extends StyledLabelProps {

--- a/src/components/atoms/Label/types.ts
+++ b/src/components/atoms/Label/types.ts
@@ -1,4 +1,5 @@
 export type StyledLabelProps = {
+  type: 'text' | 'password' | 'email' | 'search' | 'textarea';
   variant: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
   inputValue: string;
   inputHeight: number;

--- a/src/components/atoms/Label/types.ts
+++ b/src/components/atoms/Label/types.ts
@@ -1,11 +1,13 @@
-export type StyledLabelProps = {
-  type: 'text' | 'password' | 'email' | 'search' | 'textarea';
-  variant: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
+import { InputType, Variant } from '../../../types/typeAliases';
+
+export interface StyledLabelProps {
+  type: InputType;
+  variant: Variant;
   inputValue: string;
   inputHeight: number;
-};
+}
 
-export type LabelProps = StyledLabelProps & {
+export interface LabelProps extends StyledLabelProps {
   children: string;
   htmlFor: string;
-};
+}

--- a/src/components/atoms/Spinner/index.stories.tsx
+++ b/src/components/atoms/Spinner/index.stories.tsx
@@ -1,0 +1,19 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+import Spinner from './index';
+import { SpinnerProps } from './types';
+
+export default {
+  title: 'Components/Spinner',
+  component: Spinner,
+} as Meta;
+
+const Template: Story<SpinnerProps> = (args) => <Spinner {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  size: '50px',
+  color: 'secondary',
+};

--- a/src/components/atoms/Spinner/index.stories.tsx
+++ b/src/components/atoms/Spinner/index.stories.tsx
@@ -5,6 +5,16 @@ import { SpinnerProps } from './types';
 export default {
   title: 'Components/Spinner',
   component: Spinner,
+  argTypes: {
+    size: {
+      description: 'Size of spinner. Always pass value with unit e.g.: `25px`, `70%` or `4rem`',
+      defaultValue: '3rem',
+    },
+    color: {
+      description: 'Color of spinner',
+      defaultValue: 'primary',
+    },
+  },
 } as Meta;
 
 const Template: Story<SpinnerProps> = (args) => <Spinner {...args} />;

--- a/src/components/atoms/Spinner/index.tsx
+++ b/src/components/atoms/Spinner/index.tsx
@@ -1,0 +1,10 @@
+import Styled from './styles';
+import { ReactComponent as SpinnerIcon } from '../../../assets/spinner.svg';
+import { SpinnerProps } from './types';
+
+const Spinner = ({ size, color }: SpinnerProps) => (
+  <Styled.Wrapper size={size} color={color}>
+    <SpinnerIcon />
+  </Styled.Wrapper>
+);
+export default Spinner;

--- a/src/components/atoms/Spinner/styles.ts
+++ b/src/components/atoms/Spinner/styles.ts
@@ -1,0 +1,38 @@
+import styled, { css, keyframes } from 'styled-components';
+import { Colors } from '../../../types/global';
+import { SpinnerProps } from './types';
+
+const spinning = keyframes`
+    0% {
+        stroke-dashoffset: 0;
+        stroke-dasharray: 150.6 100.4;
+    }
+    50% {
+        stroke-dasharray: 1 250;
+    }
+    100% {
+        stroke-dashoffset: 502;
+        stroke-dasharray: 150.6 100.4;
+    }`;
+
+const Wrapper = styled.div<SpinnerProps>`
+  ${({ size }) => css`
+    width: ${size || '3rem'};
+    height: ${size || '3rem'};
+  `}
+
+  & .spinner {
+    width: 100%;
+    height: 100%;
+  }
+
+  & .spinner__circle {
+    stroke-width: 10px;
+    animation: 2s linear ${spinning} infinite;
+    stroke: ${({ color = 'primary', theme }) => theme.colors[Colors[color]].normal};
+  }
+`;
+
+const Styled = { Wrapper };
+
+export default Styled;

--- a/src/components/atoms/Spinner/types.ts
+++ b/src/components/atoms/Spinner/types.ts
@@ -1,0 +1,6 @@
+import { Color } from '../../../types/global';
+
+export interface SpinnerProps {
+  size?: string;
+  color?: Color;
+}

--- a/src/components/atoms/Textarea/index.tsx
+++ b/src/components/atoms/Textarea/index.tsx
@@ -1,0 +1,8 @@
+import Styled from './styles';
+import { TextareaProps } from './types';
+
+const Textarea = ({ inputHeight, inputWidth, ...rest }: TextareaProps) => (
+  <Styled.Textarea inputHeight={inputHeight} inputWidth={inputWidth} {...rest} />
+);
+
+export default Textarea;

--- a/src/components/atoms/Textarea/styles.ts
+++ b/src/components/atoms/Textarea/styles.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import { TextareaProps } from './types';
+
+const Textarea = styled.textarea<TextareaProps>`
+  resize: none;
+  outline: none;
+  width: ${({ inputWidth }) => `${inputWidth}rem`};
+  height: ${({ inputHeight }) => `${inputHeight}rem`};
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid ${({ theme }) => theme.colors.blueOutline.normal};
+`;
+
+const Styled = {
+  Textarea,
+};
+
+export default Styled;

--- a/src/components/atoms/Textarea/styles.ts
+++ b/src/components/atoms/Textarea/styles.ts
@@ -9,6 +9,11 @@ const Textarea = styled.textarea<TextareaProps>`
   padding: 1rem;
   border-radius: 1rem;
   border: 1px solid ${({ theme }) => theme.colors.blueOutline.normal};
+
+  :hover:not(:disabled),
+  :focus {
+    background-color: ${({ theme }) => theme.colors.blueOutline._030};
+  }
 `;
 
 const Styled = {

--- a/src/components/atoms/Textarea/types.ts
+++ b/src/components/atoms/Textarea/types.ts
@@ -1,0 +1,4 @@
+export interface TextareaProps {
+  inputWidth: number;
+  inputHeight: number;
+}

--- a/src/components/molecules/Checkbox/index.stories.tsx
+++ b/src/components/molecules/Checkbox/index.stories.tsx
@@ -1,0 +1,16 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+import Checkbox from './index';
+import { CheckboxProps } from './types';
+
+export default {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+} as Meta;
+
+const Template: Story<CheckboxProps> = (args) => <Checkbox {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  children: 'I want to create businness account',
+  name: 'isBusinessAccount',
+};

--- a/src/components/molecules/Checkbox/index.stories.tsx
+++ b/src/components/molecules/Checkbox/index.stories.tsx
@@ -5,6 +5,17 @@ import { CheckboxProps } from './types';
 export default {
   title: 'Components/Checkbox',
   component: Checkbox,
+  argTypes: {
+    name: {
+      description: 'Name of input. Name is also used for `id` and `htmlFor`',
+    },
+    size: {
+      description: "Width and height of CHECKBOX! in rem's ",
+    },
+    children: {
+      description: 'Input label',
+    },
+  },
 } as Meta;
 
 const Template: Story<CheckboxProps> = (args) => <Checkbox {...args} />;

--- a/src/components/molecules/Checkbox/index.tsx
+++ b/src/components/molecules/Checkbox/index.tsx
@@ -1,0 +1,14 @@
+import Styled from './styles';
+import { CheckboxProps } from './types';
+
+const Checkbox = ({ name, children, size = 2 }: CheckboxProps) => (
+  <Styled.Wrapper $size={size}>
+    <Styled.CheckboxWrapper $size={size}>
+      <Styled.CheckboxBase type="checkbox" name={name} id={name} />
+      <Styled.Checkbox />
+    </Styled.CheckboxWrapper>
+    <Styled.Label htmlFor={name}>{children}</Styled.Label>
+  </Styled.Wrapper>
+);
+
+export default Checkbox;

--- a/src/components/molecules/Checkbox/styles.ts
+++ b/src/components/molecules/Checkbox/styles.ts
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+import { StyledCheckboxProps } from './types';
+
+const Wrapper = styled.div<StyledCheckboxProps>`
+  width: fit-content;
+  display: grid;
+  grid-template-columns: ${({ $size }) => $size}rem 1fr;
+  grid-gap: 1rem;
+  align-items: center;
+`;
+
+const CheckboxBase = styled.input`
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+`;
+
+const Checkbox = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  border-radius: 0.5rem;
+  border: 0.2rem solid ${({ theme }) => theme.colors.grayColors.dark};
+  background-color: ${({ theme }) => theme.colors.grayColors.dark};
+  overflow: hidden;
+  transition: border-color 150ms ease-in-out, background-color 150ms ease-in-out;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    transition: transform 150ms ease-in-out, border-radius 50ms ease-in-out;
+    background-color: ${({ theme }) => theme.colors.white};
+  }
+
+  ${CheckboxBase}:checked + &::after {
+    transform: scale(0);
+    border-radius: 50%;
+  }
+
+  ${CheckboxBase}:hover + & {
+    border-color: ${({ theme }) => theme.colors.grayColors.light};
+    background-color: ${({ theme }) => theme.colors.grayColors.light};
+  }
+`;
+
+const CheckboxWrapper = styled.div<StyledCheckboxProps>`
+  width: ${({ $size }) => `${$size}rem`};
+  height: ${({ $size }) => `${$size}rem`};
+  border-radius: 0.5rem;
+  position: relative;
+`;
+
+const Label = styled.label`
+  font-size: 1.5rem;
+  color: ${({ theme }) => theme.colors.grayColors.dark};
+  cursor: pointer;
+`;
+
+const Styled = { CheckboxBase, Checkbox, CheckboxWrapper, Wrapper, Label };
+
+export default Styled;

--- a/src/components/molecules/Checkbox/types.ts
+++ b/src/components/molecules/Checkbox/types.ts
@@ -1,0 +1,9 @@
+export interface StyledCheckboxProps {
+  $size: number;
+}
+
+export interface CheckboxProps {
+  children: string;
+  name: string;
+  size: number;
+}

--- a/src/components/molecules/textfield/index.stories.tsx
+++ b/src/components/molecules/textfield/index.stories.tsx
@@ -3,6 +3,7 @@ import { Story, Meta } from '@storybook/react/types-6-0';
 import withFormik from 'storybook-formik';
 import * as Yup from 'yup';
 import TextField from './index';
+import argTypes from './storieArgTypes';
 import { TextFieldProps } from './types';
 
 const FormSchema = Yup.object().shape({
@@ -19,55 +20,7 @@ const FormSchema = Yup.object().shape({
 export default {
   title: 'Components/TextField',
   component: TextField,
-  argTypes: {
-    name: {
-      description: 'Name of input. Name is also used for `id` and `htmlFor`',
-      table: {
-        type: { summary: 'string' },
-        category: 'text',
-      },
-    },
-    label: {
-      table: {
-        type: { summary: 'string' },
-        category: 'text',
-      },
-    },
-    placeholder: {
-      control: { type: 'text' },
-      table: {
-        type: { summary: 'string' },
-        category: 'text',
-      },
-    },
-    inputWidth: {
-      description: "Width of input given in rem's",
-      control: { type: 'number' },
-      table: {
-        type: { summary: 'number' },
-        defaultValue: { summary: 30 },
-        category: 'size',
-      },
-    },
-    inputHeight: {
-      description: "Height of input given in rem's",
-      control: { type: 'number' },
-      table: {
-        type: { summary: 'number' },
-        defaultValue: { summary: 3.5 },
-        category: 'size',
-      },
-    },
-    disabled: {
-      description: 'Determines when input is disable or not',
-      control: { type: 'boolean' },
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: false },
-        category: 'conditions',
-      },
-    },
-  },
+  argTypes,
   decorators: [withFormik],
   parameters: {
     formik: {
@@ -124,6 +77,7 @@ export const Password = Template.bind({});
 Password.args = {
   name: 'password',
   label: 'Password',
+  type: 'password',
   variant: 'login',
   isPassword: true,
   placeholder: 'Password',

--- a/src/components/molecules/textfield/index.stories.tsx
+++ b/src/components/molecules/textfield/index.stories.tsx
@@ -1,0 +1,146 @@
+import { Story, Meta } from '@storybook/react/types-6-0';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import withFormik from 'storybook-formik';
+import TextField from './index';
+import { TextFieldProps } from './types';
+
+export default {
+  title: 'Components/TextField',
+  component: TextField,
+  argTypes: {
+    name: {
+      description: 'Name of input. Name is also used for `id` and `htmlFor`',
+      table: {
+        type: { summary: 'string' },
+        category: 'text',
+      },
+    },
+    label: {
+      table: {
+        type: { summary: 'string' },
+        category: 'text',
+      },
+    },
+    placeholder: {
+      control: { type: 'text' },
+      table: {
+        type: { summary: 'string' },
+        category: 'text',
+      },
+    },
+    inputWidth: {
+      description: "Width of input given in rem's",
+      control: { type: 'number' },
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: 30 },
+        category: 'size',
+      },
+    },
+    inputHeight: {
+      description: "Height of input given in rem's",
+      control: { type: 'number' },
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: 3.5 },
+        category: 'size',
+      },
+    },
+    disabled: {
+      description: 'Determines when input is disable or not',
+      control: { type: 'boolean' },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+        category: 'conditions',
+      },
+    },
+  },
+  decorators: [withFormik],
+  parameters: {
+    formik: {
+      initialValues: {
+        firstName: '',
+        email: '',
+      },
+    },
+  },
+} as Meta;
+
+const Template: Story<TextFieldProps> = (args) => <TextField {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  name: 'address',
+  label: 'Address',
+  inputWidth: 50,
+};
+
+export const WithDisable = Template.bind({});
+WithDisable.args = {
+  name: 'name',
+  label: 'Name',
+  variant: 'withDisable',
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  name: 'name',
+  label: 'Name',
+  disabled: true,
+  variant: 'withDisable',
+};
+
+Disabled.storyName = 'With Disable - disabled';
+
+export const Login = Template.bind({});
+Login.args = {
+  name: 'fullname',
+  label: 'Fullname',
+  variant: 'login',
+  placeholder: 'Fullname',
+};
+
+export const Password = Template.bind({});
+Password.args = {
+  name: 'password',
+  label: 'Password',
+  variant: 'login',
+  isPassword: true,
+  placeholder: 'Password',
+};
+
+export const Email = Template.bind({});
+Email.args = {
+  name: 'email',
+  label: 'Email',
+  type: 'email',
+  variant: 'login',
+  isEmail: true,
+  placeholder: 'Email',
+};
+
+export const Placeholder = Template.bind({});
+Placeholder.args = {
+  name: 'service_name',
+  label: 'Service name',
+  variant: 'placeholder',
+  placeholder: 'Service name',
+};
+
+export const Animate = Template.bind({});
+Animate.args = {
+  name: 'fullname_2',
+  label: 'Fullname',
+  variant: 'animate',
+  inputHeight: 4,
+};
+
+export const Search = Template.bind({});
+Search.args = {
+  name: 'search',
+  label: 'Search',
+  type: 'search',
+  placeholder: 'Search',
+  variant: 'search',
+};

--- a/src/components/molecules/textfield/index.stories.tsx
+++ b/src/components/molecules/textfield/index.stories.tsx
@@ -60,8 +60,14 @@ export default {
   parameters: {
     formik: {
       initialValues: {
-        firstName: '',
+        address: 'Stalowa, 11, 52, 03-425, Warszawa, Praga-Północ',
+        salonName: 'Black Cat Beauty & Spa Praga Północ',
+        fullname: '',
+        password: '',
         email: '',
+        service_name: '',
+        search: '',
+        opinion: '',
       },
     },
   },
@@ -78,14 +84,14 @@ Default.args = {
 
 export const WithDisable = Template.bind({});
 WithDisable.args = {
-  name: 'name',
+  name: 'salonName',
   label: 'Name',
   variant: 'withDisable',
 };
 
 export const Disabled = Template.bind({});
 Disabled.args = {
-  name: 'name',
+  name: 'salonName',
   label: 'Name',
   disabled: true,
   variant: 'withDisable',
@@ -130,7 +136,7 @@ Placeholder.args = {
 
 export const Animate = Template.bind({});
 Animate.args = {
-  name: 'fullname_2',
+  name: 'fullname',
   label: 'Fullname',
   variant: 'animate',
   inputHeight: 4,
@@ -143,4 +149,14 @@ Search.args = {
   type: 'search',
   placeholder: 'Search',
   variant: 'search',
+};
+
+export const Textarea = Template.bind({});
+Textarea.args = {
+  name: 'opinion',
+  label: 'Opinion',
+  type: 'textarea',
+  inputHeight: 10,
+  inputWidth: 40,
+  variant: 'animate',
 };

--- a/src/components/molecules/textfield/index.stories.tsx
+++ b/src/components/molecules/textfield/index.stories.tsx
@@ -1,6 +1,5 @@
 import { Story, Meta } from '@storybook/react/types-6-0';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import withFormik from 'storybook-formik';
+import { Formik } from 'formik';
 import * as Yup from 'yup';
 import TextField from './index';
 import argTypes from './storieArgTypes';
@@ -17,26 +16,28 @@ const FormSchema = Yup.object().shape({
   opinion: Yup.string().required('Field is required'),
 });
 
+const initialValues = {
+  address: 'Stalowa, 11, 52, 03-425, Warszawa, Praga-Północ',
+  salonName: 'Black Cat Beauty & Spa Praga Północ',
+  fullname: '',
+  password: '',
+  email: '',
+  service_name: '',
+  search: '',
+  opinion: '',
+};
+
 export default {
   title: 'Components/TextField',
   component: TextField,
   argTypes,
-  decorators: [withFormik],
-  parameters: {
-    formik: {
-      initialValues: {
-        address: 'Stalowa, 11, 52, 03-425, Warszawa, Praga-Północ',
-        salonName: 'Black Cat Beauty & Spa Praga Północ',
-        fullname: '',
-        password: '',
-        email: '',
-        service_name: '',
-        search: '',
-        opinion: '',
-      },
-      validationSchema: FormSchema,
-    },
-  },
+  decorators: [
+    (S) => (
+      <Formik initialValues={initialValues} validationSchema={FormSchema} onSubmit={() => {}}>
+        {S()}
+      </Formik>
+    ),
+  ],
 } as Meta;
 
 const Template: Story<TextFieldProps> = (args) => <TextField {...args} />;

--- a/src/components/molecules/textfield/index.stories.tsx
+++ b/src/components/molecules/textfield/index.stories.tsx
@@ -1,8 +1,20 @@
 import { Story, Meta } from '@storybook/react/types-6-0';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import withFormik from 'storybook-formik';
+import * as Yup from 'yup';
 import TextField from './index';
 import { TextFieldProps } from './types';
+
+const FormSchema = Yup.object().shape({
+  email: Yup.string().email('Invalid email').required('Field is required'),
+  address: Yup.string().required('Field is required'),
+  salonName: Yup.string().required('Field is required'),
+  fullname: Yup.string().required('Field is required'),
+  password: Yup.string().required('Field is required'),
+  service_name: Yup.string().required('Field is required'),
+  search: Yup.string().required('Field is required'),
+  opinion: Yup.string().required('Field is required'),
+});
 
 export default {
   title: 'Components/TextField',
@@ -69,6 +81,7 @@ export default {
         search: '',
         opinion: '',
       },
+      validationSchema: FormSchema,
     },
   },
 } as Meta;

--- a/src/components/molecules/textfield/index.tsx
+++ b/src/components/molecules/textfield/index.tsx
@@ -46,7 +46,7 @@ const TextField = ({
       ) : (
         <Textarea inputHeight={inputHeight} inputWidth={inputWidth} {...field} />
       )}
-      <Styled.ErrorMessage>{meta.error}</Styled.ErrorMessage>
+      {meta.touched && <Styled.ErrorMessage role="alert">{meta.error}</Styled.ErrorMessage>}
     </Styled.Wrapper>
   );
 };

--- a/src/components/molecules/textfield/index.tsx
+++ b/src/components/molecules/textfield/index.tsx
@@ -1,0 +1,42 @@
+import { useField } from 'formik';
+import { TextFieldProps } from './types';
+import Styled from './styles';
+import Input from '../../atoms/Input';
+import Label from '../../atoms/Label';
+
+const TextField = ({
+  name,
+  label,
+  placeholder = '',
+  variant = 'default',
+  type = 'text',
+  inputHeight = 3.5,
+  inputWidth = 30,
+  disabled = false,
+  isEmail = false,
+  isPassword = false,
+}: TextFieldProps) => {
+  const [field, meta] = useField(name);
+
+  return (
+    <Styled.Wrapper variant={variant}>
+      <Label variant={variant} htmlFor={name} inputValue={meta.value} inputHeight={inputHeight}>
+        {label}
+      </Label>
+      <Input
+        disabled={disabled}
+        id={name}
+        variant={variant}
+        inputHeight={inputHeight}
+        inputWidth={inputWidth}
+        placeholder={placeholder}
+        type={type}
+        isEmail={isEmail}
+        isPassword={isPassword}
+        {...field}
+      />
+    </Styled.Wrapper>
+  );
+};
+
+export default TextField;

--- a/src/components/molecules/textfield/index.tsx
+++ b/src/components/molecules/textfield/index.tsx
@@ -3,6 +3,7 @@ import { TextFieldProps } from './types';
 import Styled from './styles';
 import Input from '../../atoms/Input';
 import Label from '../../atoms/Label';
+import Textarea from '../../atoms/Textarea';
 
 const TextField = ({
   name,
@@ -20,21 +21,31 @@ const TextField = ({
 
   return (
     <Styled.Wrapper variant={variant}>
-      <Label variant={variant} htmlFor={name} inputValue={meta.value} inputHeight={inputHeight}>
+      <Label
+        type={type}
+        htmlFor={name}
+        variant={variant}
+        inputValue={meta.value}
+        inputHeight={inputHeight}
+      >
         {label}
       </Label>
-      <Input
-        disabled={disabled}
-        id={name}
-        variant={variant}
-        inputHeight={inputHeight}
-        inputWidth={inputWidth}
-        placeholder={placeholder}
-        type={type}
-        isEmail={isEmail}
-        isPassword={isPassword}
-        {...field}
-      />
+      {type !== 'textarea' ? (
+        <Input
+          disabled={disabled}
+          id={name}
+          variant={variant}
+          inputHeight={inputHeight}
+          inputWidth={inputWidth}
+          placeholder={placeholder}
+          type={type}
+          isEmail={isEmail}
+          isPassword={isPassword}
+          {...field}
+        />
+      ) : (
+        <Textarea inputHeight={inputHeight} inputWidth={inputWidth} {...field} />
+      )}
     </Styled.Wrapper>
   );
 };

--- a/src/components/molecules/textfield/index.tsx
+++ b/src/components/molecules/textfield/index.tsx
@@ -46,6 +46,7 @@ const TextField = ({
       ) : (
         <Textarea inputHeight={inputHeight} inputWidth={inputWidth} {...field} />
       )}
+      <Styled.ErrorMessage>{meta.error}</Styled.ErrorMessage>
     </Styled.Wrapper>
   );
 };

--- a/src/components/molecules/textfield/storieArgTypes.ts
+++ b/src/components/molecules/textfield/storieArgTypes.ts
@@ -1,0 +1,91 @@
+const argTypes = {
+  variant: {
+    description: 'Variant of the textfield',
+    control: {
+      type: 'radio',
+      options: ['default', 'withDisable', 'login', 'placeholder', 'animate', 'search'],
+    },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'default' },
+    },
+    defaultValue: 'default',
+  },
+  label: {
+    table: {
+      type: { summary: 'string' },
+      category: 'text',
+    },
+  },
+  name: {
+    description: 'Name of input. Name is also used for `id` and `htmlFor`',
+    table: {
+      type: { summary: 'string' },
+      category: 'text',
+    },
+  },
+  type: {
+    description: 'Type of input',
+    control: {
+      type: 'radio',
+      options: ['text', 'password', 'email', 'search', 'textarea'],
+    },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'text' },
+    },
+    defaultValue: 'text',
+  },
+  placeholder: {
+    control: { type: 'text' },
+    table: {
+      type: { summary: 'string' },
+      category: 'text',
+    },
+  },
+  inputWidth: {
+    description: "Width of input given in rem's",
+    control: { type: 'number' },
+    table: {
+      type: { summary: 'number' },
+      defaultValue: { summary: 30 },
+      category: 'size',
+    },
+  },
+  inputHeight: {
+    description: "Height of input given in rem's",
+    control: { type: 'number' },
+    table: {
+      type: { summary: 'number' },
+      defaultValue: { summary: 3.5 },
+      category: 'size',
+    },
+  },
+  disabled: {
+    description: 'Determines when input is disable or not',
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+      category: 'conditions',
+    },
+  },
+  isEmail: {
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+      category: 'conditions',
+    },
+  },
+  isPassword: {
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+      category: 'conditions',
+    },
+  },
+};
+
+export default argTypes;

--- a/src/components/molecules/textfield/styles.ts
+++ b/src/components/molecules/textfield/styles.ts
@@ -15,6 +15,13 @@ const Wrapper = styled.div<{ variant: string }>`
     `}
 `;
 
-const Styled = { Wrapper };
+const ErrorMessage = styled.p`
+  text-align: right;
+  margin-top: 0.5rem;
+  color: ${({ theme }) => theme.colors.red.normal};
+  font-size: 1.2rem;
+`;
+
+const Styled = { Wrapper, ErrorMessage };
 
 export default Styled;

--- a/src/components/molecules/textfield/styles.ts
+++ b/src/components/molecules/textfield/styles.ts
@@ -1,0 +1,20 @@
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div<{ variant: string }>`
+  display: grid;
+  width: fit-content;
+  position: relative;
+
+  ${({ variant }) =>
+    variant === 'animate' &&
+    css`
+      &:focus-within > label {
+        transform: scale(0.8) translateY(-60%);
+        z-index: 2;
+      }
+    `}
+`;
+
+const Styled = { Wrapper };
+
+export default Styled;

--- a/src/components/molecules/textfield/types.ts
+++ b/src/components/molecules/textfield/types.ts
@@ -7,7 +7,7 @@ export type StyledTextFieldProps = {
 export type TextFieldProps = StyledTextFieldProps & {
   name: string;
   label: string;
-  type?: 'text' | 'password' | 'email' | 'search';
+  type?: 'text' | 'password' | 'email' | 'search' | 'textarea';
   disabled?: boolean;
   placeholder?: string;
   isPassword?: boolean;

--- a/src/components/molecules/textfield/types.ts
+++ b/src/components/molecules/textfield/types.ts
@@ -1,0 +1,15 @@
+export type StyledTextFieldProps = {
+  variant?: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
+  inputHeight?: number;
+  inputWidth?: number;
+};
+
+export type TextFieldProps = StyledTextFieldProps & {
+  name: string;
+  label: string;
+  type?: 'text' | 'password' | 'email' | 'search';
+  disabled?: boolean;
+  placeholder?: string;
+  isPassword?: boolean;
+  isEmail?: boolean;
+};

--- a/src/components/molecules/textfield/types.ts
+++ b/src/components/molecules/textfield/types.ts
@@ -1,4 +1,4 @@
-import { InputType, Variant } from '../../../types/typeAliases';
+import { InputType, Variant } from '../../../types/global';
 
 export interface StyledTextFieldProps {
   variant?: Variant;

--- a/src/components/molecules/textfield/types.ts
+++ b/src/components/molecules/textfield/types.ts
@@ -1,15 +1,17 @@
-export type StyledTextFieldProps = {
-  variant?: 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
+import { InputType, Variant } from '../../../types/typeAliases';
+
+export interface StyledTextFieldProps {
+  variant?: Variant;
   inputHeight?: number;
   inputWidth?: number;
-};
+}
 
-export type TextFieldProps = StyledTextFieldProps & {
+export interface TextFieldProps extends StyledTextFieldProps {
   name: string;
   label: string;
-  type?: 'text' | 'password' | 'email' | 'search' | 'textarea';
+  type?: InputType;
   disabled?: boolean;
   placeholder?: string;
   isPassword?: boolean;
   isEmail?: boolean;
-};
+}

--- a/src/theme/globalStyles.ts
+++ b/src/theme/globalStyles.ts
@@ -39,7 +39,8 @@ const GlobalStyles = styled.createGlobalStyle`
   }
 
   button,
-  input {
+  input,
+  textarea {
     font-family: ${({ theme }) => theme.fonts.roboto};
   }
 `;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -16,7 +16,9 @@ const theme: DefaultTheme = {
       _010: hexToRgba('#CC3333', 10),
       _080: hexToRgba('#CC3333', 80),
     },
-    social: '#4285F4',
+    social: {
+      normal: '#4285F4',
+    },
     purple: {
       normal: '#7F4CD2',
       _005: hexToRgba('#7F4CD2', 5),
@@ -57,6 +59,7 @@ const theme: DefaultTheme = {
     },
     grayColors: {
       dark: '#9C9DA3',
+      normal: '#9C9DA3',
       dark020: hexToRgba('#9C9DA3', 20),
       dark035: hexToRgba('#9C9DA3', 35),
       dark050: hexToRgba('#9C9DA3', 50),

--- a/src/types/colors.interface.ts
+++ b/src/types/colors.interface.ts
@@ -19,6 +19,7 @@ export interface Categories {
 
 export interface GrayColors {
   dark: string;
+  normal: string;
   dark020: string;
   dark035: string;
   dark050: string;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,6 +1,7 @@
 export type Variant = 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
 export type InputType = 'text' | 'password' | 'email' | 'search' | 'textarea';
 export type ButtonType = 'button' | 'submit' | 'reset';
+export type ButtonVariant = 'default' | 'outlined' | 'contained';
 export type Color =
   | 'primary'
   | 'secondary'

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,4 +1,3 @@
 export type Variant = 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
 export type InputType = 'text' | 'password' | 'email' | 'search' | 'textarea';
-export type Size = 'verysmall' | 'small' | 'medium' | 'large';
 export type ButtonType = 'button' | 'submit' | 'reset';

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,3 +1,21 @@
 export type Variant = 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
 export type InputType = 'text' | 'password' | 'email' | 'search' | 'textarea';
 export type ButtonType = 'button' | 'submit' | 'reset';
+export type Color =
+  | 'primary'
+  | 'secondary'
+  | 'warning'
+  | 'social'
+  | 'black'
+  | 'darkgray'
+  | 'lightblue';
+
+export enum Colors {
+  primary = 'purple',
+  secondary = 'grayColors',
+  warning = 'red',
+  social = 'social',
+  black = 'black',
+  darkgray = 'dark',
+  lightblue = 'blueOutline',
+}

--- a/src/types/styled.d.ts
+++ b/src/types/styled.d.ts
@@ -11,7 +11,9 @@ declare module 'styled-components' {
       background: string;
       purple: Purple;
       red: Red;
-      social: string;
+      social: {
+        normal: string;
+      };
       dark: Dark;
       blueOutline: BlueOutline;
       categories: Categories;

--- a/src/types/typeAliases.ts
+++ b/src/types/typeAliases.ts
@@ -1,0 +1,4 @@
+export type Variant = 'default' | 'withDisable' | 'login' | 'placeholder' | 'animate' | 'search';
+export type InputType = 'text' | 'password' | 'email' | 'search' | 'textarea';
+export type Size = 'verysmall' | 'small' | 'medium' | 'large';
+export type ButtonType = 'button' | 'submit' | 'reset';


### PR DESCRIPTION
In this pull request i created:
* TextField molecule that is build of:
  * Input (default) or Textarea (when you pass `type = textarea`)
  * Label 
* Checkbox atom
* Spinner atom

I simplified the Button and ButtonIcon atoms because previously it was too complicated and unreadable.

When it comes to `spinner.svg`, i am using it besause i have more control over it than i would import it from `react-icons`.